### PR TITLE
Fix missing "Upgrade" header error

### DIFF
--- a/ixwebsocket/IXWebSocketHandshake.cpp
+++ b/ixwebsocket/IXWebSocketHandshake.cpp
@@ -466,6 +466,8 @@ namespace ix
         std::stringstream ss;
         ss << "HTTP/1.1 101\r\n";
         ss << "Sec-WebSocket-Accept: " << std::string(output) << "\r\n";
+        ss << "Upgrade: websocket\r\n";
+        ss << "Connection: websocket\r\n";
 
         // Parse the client headers. Does it support deflate ?
         std::string header = headers["sec-websocket-extensions"];


### PR DESCRIPTION
Hi, this is a quick fix of this problem. I've create a new [Issue](https://github.com/machinezone/IXWebSocket/issues/9#issue-399222657) at your repo. Hope it helps.