### PR TITLE
move security framework linking to ixwebsocket

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,10 @@ add_library( ixwebsocket STATIC
 # gcc/Linux needs -pthread
 find_package(Threads)
 
+if (APPLE AND USE_TLS)
+    target_link_libraries(ixwebsocket "-framework foundation" "-framework security")
+endif()
+
 if(UNIX AND NOT APPLE)
   find_package(OpenSSL REQUIRED)
   add_definitions(${OPENSSL_DEFINITIONS})

--- a/ws/CMakeLists.txt
+++ b/ws/CMakeLists.txt
@@ -34,9 +34,5 @@ add_executable(ws
   ws_receive.cpp
   ws.cpp)
 
-if (APPLE AND USE_TLS)
-    target_link_libraries(ws "-framework foundation" "-framework security")
-endif()
-
 target_link_libraries(ws ixwebsocket)
 install(TARGETS ws RUNTIME DESTINATION bin)


### PR DESCRIPTION
Moved to the ixwebsocket to fix linking errors on mac and ios if TLS is enabled