### PR TITLE
Ping always sent, option to disconnect on no pong response option, close code fix

### DIFF
--- a/ixwebsocket/IXWebSocket.h
+++ b/ixwebsocket/IXWebSocket.h
@@ -90,6 +90,7 @@ namespace ix
         void setPerMessageDeflateOptions(const WebSocketPerMessageDeflateOptions& perMessageDeflateOptions);
         void setHandshakeTimeout(int handshakeTimeoutSecs);
         void setHeartBeatPeriod(int heartBeatPeriod);
+        void enableDisconnectOnNoHeartBeatResponse(int heartBeatFactor = kDefaultHeartBeatPeriod);
 
         // Run asynchronously, by calling start and stop.
         void start();
@@ -154,7 +155,9 @@ namespace ix
 
         // Optional Heartbeat
         int _heartBeatPeriod;
+        int _heartBeatFactorDisconnectOnNoResponse;
         static const int kDefaultHeartBeatPeriod;
+        static const int kDefaultHeartBeatFactorDisconnectOnNoResponse;
 
         friend class WebSocketServer;
     };

--- a/ixwebsocket/IXWebSocketTransport.h
+++ b/ixwebsocket/IXWebSocketTransport.h
@@ -83,7 +83,7 @@ namespace ix
         WebSocketSendInfo sendText(const std::string& message,
                                    const OnProgressCallback& onProgressCallback);
         WebSocketSendInfo sendPing(const std::string& message);
-        void close();
+        void close(uint16_t code = 1000, const std::string& reason = "", size_t closeWireSize = 0);
         ReadyStateValues getReadyState() const;
         void setReadyState(ReadyStateValues readyStateValue);
         void setOnCloseCallback(const OnCloseCallback& onCloseCallback);
@@ -157,7 +157,7 @@ namespace ix
         std::atomic<bool> _requestInitCancellation;
 
         // Optional Heartbeat
-        std::thread _thread;
+        std::thread _heartbeatWatchdogThread;
         std::promise<void> _exitSignal;
         std::future<void> _future;
         int _heartBeatPeriod;
@@ -174,8 +174,8 @@ namespace ix
         bool heartBeatPeriodExceeded();
         // No PONG data was received through the socket for longer than (2 times) the heartbeat period
         bool pongReceiveDelayExceeded();
-        void runHeartBeat();
-        void stopHeartBeat();
+        void heartbeatWatchdogThreadFunc();
+        void stopHeartBeatWatchdogThread();
 
         void sendOnSocket();
         WebSocketSendInfo sendData(wsheader_type::opcode_type type,


### PR DESCRIPTION
Hi,
I wanted to have a regular ping no matter what we send or receive, so I changed a bit how it was done and created a thread for that.
I also added an option to disconnect if no PONG are received for a given time (factor of heartBeatPeriod) : `ixWebsocket.enableDisconnectOnNoHeartBeatResponse(2);` to wait for 2 heartbeat period 
And I fixed an issue with the close code in case it is received in IXWebSocketTransport.cpp, `close()` method
```
        if(_closeCode == 0)
        {
            _closeCode = 1000;
            _closeReason = "Normal Closure";
        }
```

Feel free to modify it as you want :)