### PR TITLE
Ping timeout use constant

### DIFF
--- a/ixwebsocket/IXWebSocketTransport.cpp
+++ b/ixwebsocket/IXWebSocketTransport.cpp
@@ -69,8 +69,8 @@ namespace ix
     const int WebSocketTransport::kDefaultPingTimeoutSecs(-1);
     const bool WebSocketTransport::kDefaultEnablePong(true);
     constexpr size_t WebSocketTransport::kChunkSize;
-    const int WebSocketTransport::kInternalErrorCode(1011);
-    const int WebSocketTransport::kAbnormalCloseCode(1006);
+    const uint16_t WebSocketTransport::kInternalErrorCode(1011);
+    const uint16_t WebSocketTransport::kAbnormalCloseCode(1006);
     const std::string WebSocketTransport::kInternalErrorMessage("Internal error");
     const std::string WebSocketTransport::kAbnormalCloseMessage("Abnormal closure");
     const std::string WebSocketTransport::kPingTimeoutMessage("Ping timeout");

--- a/ixwebsocket/IXWebSocketTransport.cpp
+++ b/ixwebsocket/IXWebSocketTransport.cpp
@@ -73,6 +73,7 @@ namespace ix
     const int WebSocketTransport::kAbnormalCloseCode(1006);
     const std::string WebSocketTransport::kInternalErrorMessage("Internal error");
     const std::string WebSocketTransport::kAbnormalCloseMessage("Abnormal closure");
+    const std::string WebSocketTransport::kPingTimeoutMessage("Ping timeout");
 
     WebSocketTransport::WebSocketTransport() :
         _useMask(true),
@@ -240,7 +241,7 @@ namespace ix
                     // exceeds the maximum delay, then close the connection
                     if (pingTimeoutExceeded())
                     {
-                        close(1011, "Ping timeout");
+                        close(kInternalErrorCode, kPingTimeoutMessage);
                     }
                     // If (1) ping is enabled and no ping has been sent for a duration 
                     // exceeding our ping interval, send a ping to the server.

--- a/ixwebsocket/IXWebSocketTransport.h
+++ b/ixwebsocket/IXWebSocketTransport.h
@@ -160,8 +160,8 @@ namespace ix
         std::atomic<bool> _requestInitCancellation;
 
         // Constants for dealing with closing conneections
-        static const int kInternalErrorCode;
-        static const int kAbnormalCloseCode;
+        static const uint16_t kInternalErrorCode;
+        static const uint16_t kAbnormalCloseCode;
         const static std::string kInternalErrorMessage;
         const static std::string kAbnormalCloseMessage;
         const static std::string kPingTimeoutMessage;

--- a/ixwebsocket/IXWebSocketTransport.h
+++ b/ixwebsocket/IXWebSocketTransport.h
@@ -164,6 +164,7 @@ namespace ix
         static const int kAbnormalCloseCode;
         const static std::string kInternalErrorMessage;
         const static std::string kAbnormalCloseMessage;
+        const static std::string kPingTimeoutMessage;
   
         // enable auto response to ping
         bool _enablePong;


### PR DESCRIPTION
- Use constants for ping timeout instead `(1011, "Ping Timeout")`
- Change type of close codes from `int` to `uint16_t`