### PR TITLE
fix ping, fix send frame close

### DIFF
--- a/ixwebsocket/IXSocket.cpp
+++ b/ixwebsocket/IXSocket.cpp
@@ -45,14 +45,14 @@ namespace ix
         close();
     }
 
-    PollResultType Socket::poll(int timeoutSecs)
+    PollResultType Socket::poll(int timeoutMs)
     {
         if (_sockfd == -1)
         {
             return PollResultType::Error;
         }
 
-        return isReadyToRead(1000 * timeoutSecs);
+        return isReadyToRead(timeoutMs);
     }
 
     PollResultType Socket::select(bool readyToRead, int timeoutMs)

--- a/ixwebsocket/IXSocket.h
+++ b/ixwebsocket/IXSocket.h
@@ -44,7 +44,7 @@ namespace ix
         void configure();
 
         // Functions to check whether there is activity on the socket
-        PollResultType poll(int timeoutSecs = kDefaultPollTimeout);
+        PollResultType poll(int timeoutMs = kDefaultPollTimeout);
         bool wakeUpFromPoll(uint8_t wakeUpCode);
 
         PollResultType isReadyToWrite(int timeoutMs);

--- a/ixwebsocket/IXWebSocket.cpp
+++ b/ixwebsocket/IXWebSocket.cpp
@@ -235,7 +235,7 @@ namespace ix
         millis duration;
 
         // Try to connect only once when we don't have automaticReconnection setup
-        if (!isConnected() && !isClosing() && !_stop && !_automaticReconnection)
+        if (!isConnectedOrClosing() && !_stop && !_automaticReconnection)
         {
             status = connect(_handshakeTimeoutSecs);
 

--- a/ixwebsocket/IXWebSocket.cpp
+++ b/ixwebsocket/IXWebSocket.cpp
@@ -257,7 +257,7 @@ namespace ix
             // Otherwise try to reconnect perpertually
             while (true)
             {
-                if (isConnected() || isClosing() || _stop || !_automaticReconnection)
+                if (isConnectedOrClosing() || _stop || !_automaticReconnection)
                 {
                     break;
                 }

--- a/ixwebsocket/IXWebSocket.h
+++ b/ixwebsocket/IXWebSocket.h
@@ -136,6 +136,7 @@ namespace ix
 
         bool isConnected() const;
         bool isClosing() const;
+        bool isConnectedOrClosing() const;
         void reconnectPerpetuallyIfDisconnected();
         std::string readyStateToString(ReadyState readyState);
         static void invokeTrafficTrackerCallback(size_t size, bool incoming);

--- a/ixwebsocket/IXWebSocketTransport.cpp
+++ b/ixwebsocket/IXWebSocketTransport.cpp
@@ -282,9 +282,9 @@ namespace ix
             }
         }
         
-        // No timeout if state is CLOSING, otherwise computed
+        // No timeout if state is not OPEN, otherwise computed
         // pingIntervalOrTimeoutGCD (equals to -1 if no ping and no ping timeout are set)
-        int lastingTimeoutDelayInMs = (_readyState == CLOSING) ? 0 : _pingIntervalOrTimeoutGCDSecs;
+        int lastingTimeoutDelayInMs = (_readyState != OPEN) ? 0 : _pingIntervalOrTimeoutGCDSecs;
 
         if (_pingIntervalOrTimeoutGCDSecs > 0)
         {

--- a/ixwebsocket/IXWebSocketTransport.cpp
+++ b/ixwebsocket/IXWebSocketTransport.cpp
@@ -602,12 +602,20 @@ namespace ix
                     bool remote = true;
                     closeSocketAndSwitchToClosedState(code, reason, _rxbuf.size(), remote);
                 }
-                // we got the CLOSE frame answer from our close, so we can close the connection if
-                // the code/reason are the same
-                else if (_closeCode == code && _closeReason == reason)
+                else
                 {
-                    bool remote = false;
-                    closeSocketAndSwitchToClosedState(code, reason, _rxbuf.size(), remote);
+                    // we got the CLOSE frame answer from our close, so we can close the connection if
+                    // the code/reason are the same
+                    bool identicalReason;
+                    {
+                        std::lock_guard<std::mutex> lock(_closeDataMutex);
+                        identicalReason = _closeCode == code && _closeReason == reason;
+                    }
+                    if (identicalReason)
+                    {
+                        bool remote = false;
+                        closeSocketAndSwitchToClosedState(code, reason, _rxbuf.size(), remote);
+                    }
                 }
             }
             else

--- a/ixwebsocket/IXWebSocketTransport.h
+++ b/ixwebsocket/IXWebSocketTransport.h
@@ -178,10 +178,12 @@ namespace ix
         static const uint16_t kInternalErrorCode;
         static const uint16_t kAbnormalCloseCode;
         static const uint16_t kProtocolErrorCode;
+        static const uint16_t kNoStatusCodeErrorCode;
         static const std::string kInternalErrorMessage;
         static const std::string kAbnormalCloseMessage;
         static const std::string kPingTimeoutMessage;
         static const std::string kProtocolErrorMessage;
+        static const std::string kNoStatusCodeErrorMessage;
 
         // enable auto response to ping
         bool _enablePong;

--- a/test/IXWebSocketPingTest.cpp
+++ b/test/IXWebSocketPingTest.cpp
@@ -355,7 +355,7 @@ TEST_CASE("Websocket_ping_data_sent_setPingInterval_full", "[setPingInterval]")
         while (true)
         {
             if (webSocketClient.isReady()) break;
-            ix::msleep(10);
+            ix::msleep(1);
         }
 
         REQUIRE(server.getClients().size() == 1);
@@ -409,7 +409,7 @@ TEST_CASE("Websocket_ping_no_data_sent_setHeartBeatPeriod", "[setHeartBeatPeriod
         while (true)
         {
             if (webSocketClient.isReady()) break;
-            ix::msleep(10);
+            ix::msleep(1);
         }
 
         REQUIRE(server.getClients().size() == 1);
@@ -452,7 +452,7 @@ TEST_CASE("Websocket_ping_data_sent_setHeartBeatPeriod", "[setHeartBeatPeriod]")
         while (true)
         {
             if (webSocketClient.isReady()) break;
-            ix::msleep(10);
+            ix::msleep(1);
         }
 
         REQUIRE(server.getClients().size() == 1);

--- a/test/IXWebSocketPingTest.cpp
+++ b/test/IXWebSocketPingTest.cpp
@@ -414,13 +414,13 @@ TEST_CASE("Websocket_ping_no_data_sent_setHeartBeatPeriod", "[setHeartBeatPeriod
 
         REQUIRE(server.getClients().size() == 1);
 
-        ix::msleep(1900);
+        ix::msleep(1850);
 
         webSocketClient.stop();
 
 
         // Here we test ping interval
-        // -> expected ping messages == 1 as 1900 seconds, 1 ping sent every second
+        // -> expected ping messages == 1 as 1850 seconds, 1 ping sent every second
         REQUIRE(serverReceivedPingMessages == 1);
 
         // Give us 500ms for the server to notice that clients went away

--- a/test/IXWebSocketPingTest.cpp
+++ b/test/IXWebSocketPingTest.cpp
@@ -461,13 +461,13 @@ TEST_CASE("Websocket_ping_data_sent_setHeartBeatPeriod", "[setHeartBeatPeriod]")
         webSocketClient.sendMessage("hello world");
         ix::msleep(900);
         webSocketClient.sendMessage("hello world");
-        ix::msleep(1000);
+        ix::msleep(900);
 
         webSocketClient.stop();
 
         // Here we test ping interval
         // client has sent data, but ping should have been sent no matter what
-        // -> expected ping messages == 2 as 900+900+1000 = 2800 seconds, 1 ping sent every second
+        // -> expected ping messages == 2 as 900+900+900 = 2700 seconds, 1 ping sent every second
         REQUIRE(serverReceivedPingMessages == 2);
 
         // Give us 500ms for the server to notice that clients went away

--- a/test/IXWebSocketPingTest.cpp
+++ b/test/IXWebSocketPingTest.cpp
@@ -461,13 +461,13 @@ TEST_CASE("Websocket_ping_data_sent_setHeartBeatPeriod", "[setHeartBeatPeriod]")
         webSocketClient.sendMessage("hello world");
         ix::msleep(900);
         webSocketClient.sendMessage("hello world");
-        ix::msleep(1010);
+        ix::msleep(1000);
 
         webSocketClient.stop();
 
         // Here we test ping interval
         // client has sent data, but ping should have been sent no matter what
-        // -> expected ping messages == 2 as 900+900+1100 = 2900 seconds, 1 ping sent every second
+        // -> expected ping messages == 2 as 900+900+1000 = 2800 seconds, 1 ping sent every second
         REQUIRE(serverReceivedPingMessages == 2);
 
         // Give us 500ms for the server to notice that clients went away

--- a/test/IXWebSocketPingTest.cpp
+++ b/test/IXWebSocketPingTest.cpp
@@ -461,7 +461,7 @@ TEST_CASE("Websocket_ping_data_sent_setHeartBeatPeriod", "[setHeartBeatPeriod]")
         webSocketClient.sendMessage("hello world");
         ix::msleep(900);
         webSocketClient.sendMessage("hello world");
-        ix::msleep(1100);
+        ix::msleep(1010);
 
         webSocketClient.stop();
 

--- a/test/IXWebSocketPingTimeoutTest.cpp
+++ b/test/IXWebSocketPingTimeoutTest.cpp
@@ -79,6 +79,7 @@ namespace
         }
 
         _webSocket.setUrl(url);
+        _webSocket.disableAutomaticReconnection();
 
         // The important bit for this test.
         // Set a ping interval, and a ping timeout
@@ -101,7 +102,6 @@ namespace
                 {
                     log("client connected");
 
-                    _webSocket.disableAutomaticReconnection();
                 }
                 else if (messageType == ix::WebSocket_MessageType_Close)
                 {
@@ -112,15 +112,11 @@ namespace
                         _closedDueToPingTimeout = true;
                     }
 
-                    _webSocket.disableAutomaticReconnection();
-
                 }
                 else if (messageType == ix::WebSocket_MessageType_Error)
                 {
                     ss << "Error ! " << error.reason;
                     log(ss.str());
-
-                    _webSocket.disableAutomaticReconnection();
                 }
                 else if (messageType == ix::WebSocket_MessageType_Pong)
                 {

--- a/test/IXWebSocketTestConnectionDisconnection.cpp
+++ b/test/IXWebSocketTestConnectionDisconnection.cpp
@@ -70,7 +70,9 @@ namespace
                 }
                 else if (messageType == ix::WebSocket_MessageType_Error)
                 {
-                    log("cmd_websocket_satori_chat: Error!");
+                    ss << "cmd_websocket_satori_chat: Error! ";
+                    ss << error.reason;
+                    log(ss.str());
                 }
                 else if (messageType == ix::WebSocket_MessageType_Message)
                 {
@@ -83,6 +85,10 @@ namespace
                 else if (messageType == ix::WebSocket_MessageType_Pong)
                 {
                     log("cmd_websocket_satori_chat: received pong message.!");
+                }
+                else if (messageType == ix::WebSocket_MessageType_Fragment)
+                {
+                    log("cmd_websocket_satori_chat: received fragment.!");
                 }
                 else
                 {
@@ -117,11 +123,11 @@ TEST_CASE("websocket_connections", "[websocket]")
     SECTION("Try to connect and disconnect with different timing.")
     {
         IXWebSocketTestConnectionDisconnection chatA;
-        for (int i = 0; i < 50; ++i)
+        for (int i = 0; i < 20; ++i)
         {
             log(std::string("Run: ") + std::to_string(i));
             chatA.start(WEBSOCKET_DOT_ORG_URL);
-            ix::msleep(i);
+            ix::msleep(i*50);
             chatA.stop();
         }
     }

--- a/test/IXWebSocketTestConnectionDisconnection.cpp
+++ b/test/IXWebSocketTestConnectionDisconnection.cpp
@@ -123,11 +123,11 @@ TEST_CASE("websocket_connections", "[websocket]")
     SECTION("Try to connect and disconnect with different timing.")
     {
         IXWebSocketTestConnectionDisconnection chatA;
-        for (int i = 0; i < 20; ++i)
+        for (int i = 0; i < 50; ++i)
         {
             log(std::string("Run: ") + std::to_string(i));
             chatA.start(WEBSOCKET_DOT_ORG_URL);
-            ix::msleep(i*50);
+            ix::msleep(i);
             chatA.stop();
         }
     }


### PR DESCRIPTION
- Fix ping timeout
- Fix an issue about callback/code read from remote.
When we close the connection using close(code, reason...), a CLOSE frame is sent to the remote, and then right after we really close the socket connection. On the remote side, the CLOSE frame data are read, then the connection is immediately closed so the close callback is called with 1006 / Abnormal close instead of the values of the CLOSE frame, because these data are not processed in the dispatch yet. The fix is to close the connection, set that we need to read the buffer, and if nothing triggered a CLOSED state with the data read, then call the callback with 1006 / Abnormal close