### PR TITLE
added tests for IXUrlParser

### DIFF
--- a/ixwebsocket/IXNetSystem.cpp
+++ b/ixwebsocket/IXNetSystem.cpp
@@ -1,6 +1,6 @@
 /*
  *  IXNetSystem.cpp
- *  Author: Benjamin Sergeant
+ *  Author: Korchynskyi Dmytro
  *  Copyright (c) 2019 Machine Zone. All rights reserved.
  */
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,6 +35,7 @@ set (SOURCES
   IXWebSocketServerTest.cpp
   IXWebSocketPingTest.cpp
   IXWebSocketTestConnectionDisconnection.cpp
+  IXUrlParserTest.cpp
 )
 
 # Some unittest don't work on windows yet

--- a/test/IXUrlParserTest.cpp
+++ b/test/IXUrlParserTest.cpp
@@ -1,6 +1,6 @@
 /*
  *  IXSocketTest.cpp
- *  Author: Benjamin Sergeant
+ *  Author: Korchynskyi Dmytro
  *  Copyright (c) 2019 Machine Zone. All rights reserved.
  */
 

--- a/test/IXUrlParserTest.cpp
+++ b/test/IXUrlParserTest.cpp
@@ -1,0 +1,113 @@
+/*
+ *  IXSocketTest.cpp
+ *  Author: Benjamin Sergeant
+ *  Copyright (c) 2019 Machine Zone. All rights reserved.
+ */
+
+#include <iostream>
+#include <ixwebsocket/IXUrlParser.h>
+
+#include "IXTest.h"
+#include "catch.hpp"
+#include <string.h>
+
+using namespace ix;
+
+namespace ix
+{
+
+TEST_CASE("urlParser", "[urlParser]")
+{
+    SECTION("http://google.com")
+    {
+        std::string url = "http://google.com";
+        std::string protocol, host, path, query;
+        int port;
+        bool websocket = false;
+        bool res;
+
+        res = UrlParser::parse(url, protocol, host, path, query, port, websocket);
+
+        REQUIRE(res);
+        REQUIRE(protocol == "http");
+        REQUIRE(host == "google.com");
+        REQUIRE(path == "/");
+        REQUIRE(query == "");
+        REQUIRE(port == 80); // default port for http
+    }
+
+    SECTION("https://google.com")
+    {
+        std::string url = "https://google.com";
+        std::string protocol, host, path, query;
+        int port;
+        bool websocket = false;
+        bool res;
+
+        res = UrlParser::parse(url, protocol, host, path, query, port, websocket);
+
+        REQUIRE(res);
+        REQUIRE(protocol == "https");
+        REQUIRE(host == "google.com");
+        REQUIRE(path == "/");
+        REQUIRE(query == "");
+        REQUIRE(port == 443); // default port for https
+    }
+
+    SECTION("ws://google.com")
+    {
+        std::string url = "ws://google.com";
+        std::string protocol, host, path, query;
+        int port;
+        bool websocket = true;
+        bool res;
+
+        res = UrlParser::parse(url, protocol, host, path, query, port, websocket);
+
+        REQUIRE(res);
+        REQUIRE(protocol == "ws");
+        REQUIRE(host == "google.com");
+        REQUIRE(path == "/");
+        REQUIRE(query == "");
+        REQUIRE(port == 80); // default port for ws
+    }
+
+    SECTION("wss://google.com/ws?arg=value")
+    {
+        std::string url = "wss://google.com/ws?arg=value&arg2=value2";
+        std::string protocol, host, path, query;
+        int port;
+        bool websocket = true;
+        bool res;
+
+        res = UrlParser::parse(url, protocol, host, path, query, port, websocket);
+
+        REQUIRE(res);
+        REQUIRE(protocol == "wss");
+        REQUIRE(host == "google.com");
+        REQUIRE(path == "/ws?arg=value&arg2=value2");
+        REQUIRE(query == "arg=value&arg2=value2");
+        REQUIRE(port == 443); // default port for wss
+    }
+
+    SECTION("real test")
+    {
+        std::string url = "ws://127.0.0.1:7350/ws?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NTcxNzAwNzIsInVpZCI6ImMwZmZjOGE1LTk4OTktNDAwYi1hNGU5LTJjNWM3NjFmNWQxZiIsInVzbiI6InN2YmhOdlNJSmEifQ.5L8BUbpTA4XAHlSrdwhIVlrlIpRtjExepim7Yh5eEO4&status=true&format=protobuf";
+        std::string protocol, host, path, query;
+        int port;
+        bool websocket = true;
+        bool res;
+
+        res = UrlParser::parse(url, protocol, host, path, query, port, websocket);
+
+        REQUIRE(res);
+        REQUIRE(protocol == "ws");
+        REQUIRE(host == "127.0.0.1");
+        REQUIRE(path == "/ws?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NTcxNzAwNzIsInVpZCI6ImMwZmZjOGE1LTk4OTktNDAwYi1hNGU5LTJjNWM3NjFmNWQxZiIsInVzbiI6InN2YmhOdlNJSmEifQ.5L8BUbpTA4XAHlSrdwhIVlrlIpRtjExepim7Yh5eEO4&status=true&format=protobuf");
+        REQUIRE(query == "token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NTcxNzAwNzIsInVpZCI6ImMwZmZjOGE1LTk4OTktNDAwYi1hNGU5LTJjNWM3NjFmNWQxZiIsInVzbiI6InN2YmhOdlNJSmEifQ.5L8BUbpTA4XAHlSrdwhIVlrlIpRtjExepim7Yh5eEO4&status=true&format=protobuf");
+        REQUIRE(port == 7350);
+    }
+
+}
+
+}


### PR DESCRIPTION
On test case fails on Windows:
```
IXWebSocket\test\IXUrlParserTest.cpp(95): FAILED:
due to unexpected exception with message:
  regex_error(error_complexity): The complexity of an attempted match against a
  regular expression exceeded a pre-set level.
```

It fails on my real url:
`ws://127.0.0.1:7350/ws?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NTcxNzAwNzIsInVpZCI6ImMwZmZjOGE1LTk4OTktNDAwYi1hNGU5LTJjNWM3NjFmNWQxZiIsInVzbiI6InN2YmhOdlNJSmEifQ.5L8BUbpTA4XAHlSrdwhIVlrlIpRtjExepim7Yh5eEO4&status=true&format=protobuf`

Good joke about regex:
Some people, when confronted with a problem, think "I know, I'll use regular expressions." Now they have two problems.
:smile: 