### PR TITLE
Fail test GCC TSAN

### DIFF
--- a/test/IXWebSocketTestConnectionDisconnection.cpp
+++ b/test/IXWebSocketTestConnectionDisconnection.cpp
@@ -126,7 +126,7 @@ TEST_CASE("websocket_connections", "[websocket]")
         }
     }
 
-    SECTION("Try to connect and disconnect with different timing, from not enough time to successfull connect")
+    /*SECTION("Try to connect and disconnect with different timing, from not enough time to successfull connect")
     {
         IXWebSocketTestConnectionDisconnection chatA;
         for (int i = 0; i < 20; ++i)
@@ -136,5 +136,5 @@ TEST_CASE("websocket_connections", "[websocket]")
             ix::msleep(i*50);
             chatA.stop();
         }
-    }
+    }*/
 }

--- a/test/IXWebSocketTestConnectionDisconnection.cpp
+++ b/test/IXWebSocketTestConnectionDisconnection.cpp
@@ -114,7 +114,7 @@ TEST_CASE("websocket_connections", "[websocket]")
         chatA.stop();
     }
 
-    SECTION("Try to connect and disconnect with different timing.")
+    SECTION("Try to connect and disconnect with different timing, not enough time to succesfully connect")
     {
         IXWebSocketTestConnectionDisconnection chatA;
         for (int i = 0; i < 50; ++i)
@@ -122,6 +122,18 @@ TEST_CASE("websocket_connections", "[websocket]")
             log(std::string("Run: ") + std::to_string(i));
             chatA.start(WEBSOCKET_DOT_ORG_URL);
             ix::msleep(i);
+            chatA.stop();
+        }
+    }
+
+    SECTION("Try to connect and disconnect with different timing, from not enough time to successfull connect")
+    {
+        IXWebSocketTestConnectionDisconnection chatA;
+        for (int i = 0; i < 20; ++i)
+        {
+            log(std::string("Run: ") + std::to_string(i));
+            chatA.start(WEBSOCKET_DOT_ORG_URL);
+            ix::msleep(i*50);
             chatA.stop();
         }
     }


### PR DESCRIPTION
On Linux with GCC there are TSAN errors, the data race seems to happen the first time the thread has enough time to successfully connect (after handshake). After the successful, it's ok, and before each attempt stopped before success, it's ok too. The index where the change occurs depends on the running computer, ie on Travis it's Run 3, on mine it's Run 8
We could reduce the test loop to this too:
```
SECTION("Try to connect to invalid servers.")
    {
        IXWebSocketTestConnectionDisconnection chatA;
        // not enough time to connect
        chatA.start(WEBSOCKET_DOT_ORG_URL);
        ix::msleep(7*50);
        chatA.stop();
        // enough time to connect
        chatA.start(WEBSOCKET_DOT_ORG_URL);
        ix::msleep(8*50);
        chatA.stop();
    }
```
the error will appear