### PR TITLE
Fix crash during closing on Windows

### DIFF
--- a/ixwebsocket/IXWebSocket.h
+++ b/ixwebsocket/IXWebSocket.h
@@ -91,7 +91,6 @@ namespace ix
 
         void setUrl(const std::string& url);
         void setPerMessageDeflateOptions(const WebSocketPerMessageDeflateOptions& perMessageDeflateOptions);
-        void setHandshakeTimeout(int handshakeTimeoutSecs);
         void setHeartBeatPeriod(int heartBeatPeriodSecs);
         void setPingInterval(int pingIntervalSecs); // alias of setHeartBeatPeriod
         void setPingTimeout(int pingTimeoutSecs);
@@ -100,6 +99,7 @@ namespace ix
 
         // Run asynchronously, by calling start and stop.
         void start();
+        // stop is synchronous
         void stop();
 
         // Run in blocking mode, by connecting first manually, and then calling run.
@@ -136,13 +136,11 @@ namespace ix
 
         bool isConnected() const;
         bool isClosing() const;
-        bool isConnectedOrClosing() const;
-        void reconnectPerpetuallyIfDisconnected();
+        void checkConnection(bool initial);
         std::string readyStateToString(ReadyState readyState);
         static void invokeTrafficTrackerCallback(size_t size, bool incoming);
 
         // Server
-        void setSocketFileDescriptor(int fd);
         WebSocketInitResult connectToSocket(int fd, int timeoutSecs);
 
         WebSocketTransport _ws;

--- a/ixwebsocket/IXWebSocketErrorInfo.h
+++ b/ixwebsocket/IXWebSocketErrorInfo.h
@@ -12,10 +12,10 @@ namespace ix
 {
     struct WebSocketErrorInfo
     {
-        uint32_t retries;
-        double wait_time;
-        int http_status;
+        uint32_t retries = 0;
+        double wait_time = 0;
+        int http_status = 0;
         std::string reason;
-        bool decompressionError;
+        bool decompressionError = false;
     };
 }

--- a/test/IXWebSocketTestConnectionDisconnection.cpp
+++ b/test/IXWebSocketTestConnectionDisconnection.cpp
@@ -132,7 +132,7 @@ TEST_CASE("websocket_connections", "[websocket]")
         }
     }
 
-    SECTION("Try to connect and disconnect with different timing, from not enough time to successfull connect")
+    /*SECTION("Try to connect and disconnect with different timing, from not enough time to successfull connect")
     {
         IXWebSocketTestConnectionDisconnection chatA;
         for (int i = 0; i < 20; ++i)
@@ -142,5 +142,5 @@ TEST_CASE("websocket_connections", "[websocket]")
             ix::msleep(i*50);
             chatA.stop();
         }
-    }
+    }*/
 }

--- a/test/IXWebSocketTestConnectionDisconnection.cpp
+++ b/test/IXWebSocketTestConnectionDisconnection.cpp
@@ -132,7 +132,7 @@ TEST_CASE("websocket_connections", "[websocket]")
         }
     }
 
-    /*SECTION("Try to connect and disconnect with different timing, from not enough time to successfull connect")
+    SECTION("Try to connect and disconnect with different timing, from not enough time to successfull connect")
     {
         IXWebSocketTestConnectionDisconnection chatA;
         for (int i = 0; i < 20; ++i)
@@ -142,5 +142,5 @@ TEST_CASE("websocket_connections", "[websocket]")
             ix::msleep(i*50);
             chatA.stop();
         }
-    }*/
+    }
 }


### PR DESCRIPTION
It crashes when `createSocket` fails to create socket on Windows because no SSL support.

Would be good to simulate error when creating socket.
@bsergean how to do that?