### PR TITLE
let poll do his job when closing

### DIFF
--- a/ixwebsocket/IXWebSocket.cpp
+++ b/ixwebsocket/IXWebSocket.cpp
@@ -293,8 +293,8 @@ namespace ix
                 break;
             }
 
-            // We cannot enter poll which might block forever if we are stopping
-            if (_stop) break;
+            // We can avoid to poll if we want to stop and are not closing
+            if (_stop && !isClosing()) break;
 
             // 2. Poll to see if there's any new data available
             WebSocketTransport::PollResult pollResult = _ws.poll();

--- a/ixwebsocket/IXWebSocketTransport.cpp
+++ b/ixwebsocket/IXWebSocketTransport.cpp
@@ -71,7 +71,7 @@ namespace ix
     const int WebSocketTransport::kDefaultPingIntervalSecs(-1);
     const int WebSocketTransport::kDefaultPingTimeoutSecs(-1);
     const bool WebSocketTransport::kDefaultEnablePong(true);
-    const int WebSocketTransport::kClosingMaximumWaitingDelayInMs(200);
+    const int WebSocketTransport::kClosingMaximumWaitingDelayInMs(300);
     constexpr size_t WebSocketTransport::kChunkSize;
 
     WebSocketTransport::WebSocketTransport() :

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ set (SOURCES
   IXWebSocketTestConnectionDisconnection.cpp
   IXUrlParserTest.cpp
   IXWebSocketServerTest.cpp
+  IXWebSocketCloseTest.cpp
 )
 
 # Some unittest don't work on windows yet
@@ -50,7 +51,6 @@ endif()
 # Disable tests for now that are failing or not reliable
 # IXWebSocketPingTest.cpp
 # IXWebSocketPingTimeoutTest.cpp
-# IXWebSocketCloseTest.cpp
 # IXWebSocketMessageQTest.cpp (trigger a segfault on Linux)
 
 add_executable(ixwebsocket_unittest ${SOURCES})

--- a/test/IXWebSocketCloseTest.cpp
+++ b/test/IXWebSocketCloseTest.cpp
@@ -102,6 +102,7 @@ namespace
         }
 
         _webSocket.setUrl(url);
+        _webSocket.disableAutomaticReconnection();
 
         std::stringstream ss;
         log(std::string("Connecting to url: ") + url);
@@ -118,8 +119,6 @@ namespace
                 if (messageType == ix::WebSocketMessageType::Open)
                 {
                     log("client connected");
-
-                    _webSocket.disableAutomaticReconnection();
                 }
                 else if (messageType == ix::WebSocketMessageType::Close)
                 {
@@ -130,15 +129,11 @@ namespace
                     _closeCode = closeInfo.code;
                     _closeReason = std::string(closeInfo.reason);
                     _closeRemote = closeInfo.remote;
-
-                    _webSocket.disableAutomaticReconnection();
                 }
                 else if (messageType == ix::WebSocketMessageType::Error)
                 {
                     ss << "Error ! " << error.reason;
                     log(ss.str());
-
-                    _webSocket.disableAutomaticReconnection();
                 }
                 else if (messageType == ix::WebSocketMessageType::Pong)
                 {
@@ -261,11 +256,11 @@ TEST_CASE("Websocket_client_close_default", "[close]")
 
         REQUIRE(server.getClients().size() == 1);
 
-        ix::msleep(100);
+        ix::msleep(300);
 
         webSocketClient.stop();
 
-        ix::msleep(200);
+        ix::msleep(300);
 
         // ensure client close is the same as values given
         REQUIRE(webSocketClient.getCloseCode() == 1000);
@@ -319,11 +314,11 @@ TEST_CASE("Websocket_client_close_params_given", "[close]")
 
         REQUIRE(server.getClients().size() == 1);
 
-        ix::msleep(100);
+        ix::msleep(300);
 
         webSocketClient.stop(4000, "My reason");
 
-        ix::msleep(500);
+        ix::msleep(300);
 
         // ensure client close is the same as values given
         REQUIRE(webSocketClient.getCloseCode() == 4000);
@@ -377,11 +372,11 @@ TEST_CASE("Websocket_server_close", "[close]")
 
         REQUIRE(server.getClients().size() == 1);
 
-        ix::msleep(200);
+        ix::msleep(300);
 
         server.stop();
 
-        ix::msleep(500);
+        ix::msleep(300);
 
         // ensure client close is the same as values given
         REQUIRE(webSocketClient.getCloseCode() == 1000);


### PR DESCRIPTION
It's like before, the same bug I fixed came back :)
We have to let the poll() do his job if we are in the closing state, there won't be a poll waiting forever has a little timeout is set in Transport for state != OPEN
Btw here no callback was called at all before the fix