### PR TITLE
WIP: support configurable certificates/keys, and root trust CAs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set( IXWEBSOCKET_SOURCES
     ixwebsocket/IXSocketConnect.cpp
     ixwebsocket/IXSocketFactory.cpp
     ixwebsocket/IXSocketServer.cpp
+    ixwebsocket/IXSocketTLSOptions.cpp
     ixwebsocket/IXUrlParser.cpp
     ixwebsocket/IXUserAgent.cpp
     ixwebsocket/IXWebSocket.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ set( IXWEBSOCKET_HEADERS
     ixwebsocket/IXSocketConnect.h
     ixwebsocket/IXSocketFactory.h
     ixwebsocket/IXSocketServer.h
+    ixwebsocket/IXSocketTLSOptions.h
     ixwebsocket/IXUrlParser.h
     ixwebsocket/IXUtf8Validator.h
     ixwebsocket/IXUserAgent.h

--- a/ixwebsocket/IXSocketFactory.cpp
+++ b/ixwebsocket/IXSocketFactory.cpp
@@ -8,15 +8,15 @@
 
 #ifdef IXWEBSOCKET_USE_TLS
 
-# ifdef IXWEBSOCKET_USE_MBED_TLS
-#  include <ixwebsocket/IXSocketMbedTLS.h>
-# elif __APPLE__
-#  include <ixwebsocket/IXSocketAppleSSL.h>
-# elif defined(_WIN32)
-#  include <ixwebsocket/IXSocketSChannel.h>
-# elif defined(IXWEBSOCKET_USE_OPEN_SSL)
-#  include <ixwebsocket/IXSocketOpenSSL.h>
-# endif
+#ifdef IXWEBSOCKET_USE_MBED_TLS
+#include <ixwebsocket/IXSocketMbedTLS.h>
+#elif __APPLE__
+#include <ixwebsocket/IXSocketAppleSSL.h>
+#elif defined(_WIN32)
+#include <ixwebsocket/IXSocketSChannel.h>
+#elif defined(IXWEBSOCKET_USE_OPEN_SSL)
+#include <ixwebsocket/IXSocketOpenSSL.h>
+#endif
 
 #else
 
@@ -40,15 +40,15 @@ namespace ix
         else
         {
 #ifdef IXWEBSOCKET_USE_TLS
-# if defined(IXWEBSOCKET_USE_MBED_TLS)
+#if defined(IXWEBSOCKET_USE_MBED_TLS)
             socket = std::make_shared<SocketMbedTLS>(tlsOptions);
-# elif defined(__APPLE__)
+#elif defined(__APPLE__)
             socket = std::make_shared<SocketAppleSSL>(tlsOptions);
-# elif defined(_WIN32)
+#elif defined(_WIN32)
             socket = std::make_shared<SocketSChannel>(tlsOptions);
-# else
+#else
             socket = std::make_shared<SocketOpenSSL>(tlsOptions);
-# endif
+#endif
 #else
             errorMsg = "TLS support is not enabled on this platform.";
             return nullptr;
@@ -63,8 +63,7 @@ namespace ix
         return socket;
     }
 
-    std::shared_ptr<Socket> createSocket(int fd,
-                                         std::string& errorMsg)
+    std::shared_ptr<Socket> createSocket(int fd, std::string& errorMsg)
     {
         errorMsg.clear();
 
@@ -76,4 +75,4 @@ namespace ix
 
         return socket;
     }
-}
+} // namespace ix

--- a/ixwebsocket/IXSocketFactory.cpp
+++ b/ixwebsocket/IXSocketFactory.cpp
@@ -27,7 +27,8 @@
 namespace ix
 {
     std::shared_ptr<Socket> createSocket(bool tls,
-                                         std::string& errorMsg)
+                                         std::string& errorMsg,
+                                         const SocketTLSOptions& tlsOptions)
     {
         errorMsg.clear();
         std::shared_ptr<Socket> socket;
@@ -40,13 +41,13 @@ namespace ix
         {
 #ifdef IXWEBSOCKET_USE_TLS
 # if defined(IXWEBSOCKET_USE_MBED_TLS)
-            socket = std::make_shared<SocketMbedTLS>();
+            socket = std::make_shared<SocketMbedTLS>(tlsOptions);
 # elif defined(__APPLE__)
-            socket = std::make_shared<SocketAppleSSL>();
+            socket = std::make_shared<SocketAppleSSL>(tlsOptions);
 # elif defined(_WIN32)
-            socket = std::make_shared<SocketSChannel>();
+            socket = std::make_shared<SocketSChannel>(tlsOptions);
 # else
-            socket = std::make_shared<SocketOpenSSL>();
+            socket = std::make_shared<SocketOpenSSL>(tlsOptions);
 # endif
 #else
             errorMsg = "TLS support is not enabled on this platform.";

--- a/ixwebsocket/IXSocketFactory.h
+++ b/ixwebsocket/IXSocketFactory.h
@@ -10,10 +10,12 @@
 #include <memory>
 #include <string>
 
+#include "IXSocketTLSOptions.h"
+
 namespace ix
 {
     class Socket;
-    std::shared_ptr<Socket> createSocket(bool tls, std::string& errorMsg);
+    std::shared_ptr<Socket> createSocket(bool tls, std::string& errorMsg, const SocketTLSOptions& tlsOptions);
 
     std::shared_ptr<Socket> createSocket(int fd, std::string& errorMsg);
 } // namespace ix

--- a/ixwebsocket/IXSocketOpenSSL.cpp
+++ b/ixwebsocket/IXSocketOpenSSL.cpp
@@ -270,18 +270,18 @@ namespace ix
                 if (SSL_CTX_use_certificate_chain_file(_ssl_context,
                                                        _tlsOptions.certFile.c_str()) != 1)
                 {
-                    auto ssl_err = ERR_get_error();
+                    auto sslErr = ERR_get_error();
                     errMsg = "OpenSSL failed - SSL_CTX_use_certificate_chain_file(\"" +
                              _tlsOptions.certFile + "\") failed: ";
-                    errMsg += ERR_error_string(ssl_err, nullptr);
+                    errMsg += ERR_error_string(sslErr, nullptr);
                 }
                 else if (SSL_CTX_use_PrivateKey_file(
                              _ssl_context, _tlsOptions.keyFile.c_str(), SSL_FILETYPE_PEM) != 1)
                 {
-                    auto ssl_err = ERR_get_error();
+                    auto sslErr = ERR_get_error();
                     errMsg = "OpenSSL failed - SSL_CTX_use_PrivateKey_file(\"" +
                              _tlsOptions.keyFile + "\") failed: ";
-                    errMsg += ERR_error_string(ssl_err, nullptr);
+                    errMsg += ERR_error_string(sslErr, nullptr);
                 }
             }
 
@@ -293,9 +293,9 @@ namespace ix
                 {
                     if (SSL_CTX_set_default_verify_paths(_ssl_context) == 0)
                     {
-                        auto ssl_err = ERR_get_error();
+                        auto sslErr = ERR_get_error();
                         errMsg = "OpenSSL failed - SSL_CTX_default_verify_paths loading failed: ";
-                        errMsg += ERR_error_string(ssl_err, nullptr);
+                        errMsg += ERR_error_string(sslErr, nullptr);
                     }
                 }
                 else
@@ -305,20 +305,20 @@ namespace ix
                     rootCAs = SSL_load_client_CA_file(root_ca_file);
                     if (rootCAs == NULL)
                     {
-                        auto ssl_err = ERR_get_error();
+                        auto sslErr = ERR_get_error();
                         errMsg = "OpenSSL failed - SSL_load_client_CA_file('" + _tlsOptions.caFile +
                                  "') failed: ";
-                        errMsg += ERR_error_string(ssl_err, nullptr);
+                        errMsg += ERR_error_string(sslErr, nullptr);
                     }
                     else
                     {
                         SSL_CTX_set_client_CA_list(_ssl_context, rootCAs);
                         if (SSL_CTX_load_verify_locations(_ssl_context, root_ca_file, NULL) != 1)
                         {
-                            auto ssl_err = ERR_get_error();
+                            auto sslErr = ERR_get_error();
                             errMsg = "OpenSSL failed - SSL_CTX_load_verify_locations(\"" +
                                      _tlsOptions.caFile + "\") failed: ";
-                            errMsg += ERR_error_string(ssl_err, nullptr);
+                            errMsg += ERR_error_string(sslErr, nullptr);
                         }
                     }
                 }

--- a/ixwebsocket/IXSocketOpenSSL.cpp
+++ b/ixwebsocket/IXSocketOpenSSL.cpp
@@ -270,16 +270,16 @@ namespace ix
             ERR_clear_error();
             if (_tlsOptions.isUsingClientCert()) {
                 if (SSL_CTX_use_certificate_chain_file(_ssl_context, 
-                        _tlsOptions.cert_file.c_str()) != 1) {
+                        _tlsOptions.certFile.c_str()) != 1) {
                     unsigned long ssl_err = ERR_get_error();
                     errMsg = "OpenSSL failed - SSL_CTX_use_certificate_chain_file(\""
-                            + _tlsOptions.cert_file + "\") failed: ";
+                            + _tlsOptions.certFile + "\") failed: ";
                     errMsg += ERR_error_string(ssl_err, nullptr);
                 } else if (SSL_CTX_use_PrivateKey_file(_ssl_context, 
-                        _tlsOptions.key_file.c_str(), SSL_FILETYPE_PEM) != 1) {
+                        _tlsOptions.keyFile.c_str(), SSL_FILETYPE_PEM) != 1) {
                     unsigned long ssl_err = ERR_get_error();
                     errMsg = "OpenSSL failed - SSL_CTX_use_PrivateKey_file(\""
-                            + _tlsOptions.key_file + "\") failed: ";
+                            + _tlsOptions.keyFile + "\") failed: ";
                     errMsg += ERR_error_string(ssl_err, nullptr);
                 }
             }
@@ -297,20 +297,20 @@ namespace ix
                         errMsg += ERR_error_string(ssl_err, nullptr);
                     }
                 } else {
-                    const char * root_ca_file = _tlsOptions.ca_file.c_str();
+                    const char * root_ca_file = _tlsOptions.caFile.c_str();
                     STACK_OF(X509_NAME) *root_cas;
                     root_cas = SSL_load_client_CA_file(root_ca_file);
                     if (root_cas == NULL) {
                         unsigned long ssl_err = ERR_get_error();
                         errMsg = "OpenSSL failed - SSL_load_client_CA_file('"
-                                 + _tlsOptions.ca_file + "') failed: ";
+                                 + _tlsOptions.caFile + "') failed: ";
                         errMsg += ERR_error_string(ssl_err, nullptr);
                     } else {
                         SSL_CTX_set_client_CA_list(_ssl_context, root_cas); 
                         if (SSL_CTX_load_verify_locations(_ssl_context, root_ca_file, NULL) != 1) {
                             unsigned long ssl_err = ERR_get_error();
                             errMsg = "OpenSSL failed - SSL_CTX_load_verify_locations(\""
-                                    + _tlsOptions.ca_file + "\") failed: ";
+                                    + _tlsOptions.caFile + "\") failed: ";
                             errMsg += ERR_error_string(ssl_err, nullptr);
                         }
                     }

--- a/ixwebsocket/IXSocketOpenSSL.cpp
+++ b/ixwebsocket/IXSocketOpenSSL.cpp
@@ -115,12 +115,13 @@ namespace ix
         {
             if (!_tlsOptions.isPeerVerifyDisabled())
             {
-                // To skip verification, pass in SSL_VERIFY_NONE
                 SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, [](int preverify, X509_STORE_CTX*) -> int {
                     return preverify;
                 });
 
                 SSL_CTX_set_verify_depth(ctx, 4);
+            } else {
+                SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, nullptr);
             }
 
             SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);

--- a/ixwebsocket/IXSocketOpenSSL.cpp
+++ b/ixwebsocket/IXSocketOpenSSL.cpp
@@ -270,7 +270,7 @@ namespace ix
                 if (SSL_CTX_use_certificate_chain_file(_ssl_context,
                                                        _tlsOptions.certFile.c_str()) != 1)
                 {
-                    unsigned long ssl_err = ERR_get_error();
+                    auto ssl_err = ERR_get_error();
                     errMsg = "OpenSSL failed - SSL_CTX_use_certificate_chain_file(\"" +
                              _tlsOptions.certFile + "\") failed: ";
                     errMsg += ERR_error_string(ssl_err, nullptr);
@@ -278,7 +278,7 @@ namespace ix
                 else if (SSL_CTX_use_PrivateKey_file(
                              _ssl_context, _tlsOptions.keyFile.c_str(), SSL_FILETYPE_PEM) != 1)
                 {
-                    unsigned long ssl_err = ERR_get_error();
+                    auto ssl_err = ERR_get_error();
                     errMsg = "OpenSSL failed - SSL_CTX_use_PrivateKey_file(\"" +
                              _tlsOptions.keyFile + "\") failed: ";
                     errMsg += ERR_error_string(ssl_err, nullptr);
@@ -291,10 +291,9 @@ namespace ix
             {
                 if (_tlsOptions.isUsingSystemDefaults())
                 {
-                    int cert_load_result = SSL_CTX_set_default_verify_paths(_ssl_context);
-                    if (cert_load_result == 0)
+                    if (SSL_CTX_set_default_verify_paths(_ssl_context) == 0)
                     {
-                        unsigned long ssl_err = ERR_get_error();
+                        auto ssl_err = ERR_get_error();
                         errMsg = "OpenSSL failed - SSL_CTX_default_verify_paths loading failed: ";
                         errMsg += ERR_error_string(ssl_err, nullptr);
                     }
@@ -302,21 +301,21 @@ namespace ix
                 else
                 {
                     const char* root_ca_file = _tlsOptions.caFile.c_str();
-                    STACK_OF(X509_NAME) * root_cas;
-                    root_cas = SSL_load_client_CA_file(root_ca_file);
-                    if (root_cas == NULL)
+                    STACK_OF(X509_NAME) * rootCAs;
+                    rootCAs = SSL_load_client_CA_file(root_ca_file);
+                    if (rootCAs == NULL)
                     {
-                        unsigned long ssl_err = ERR_get_error();
+                        auto ssl_err = ERR_get_error();
                         errMsg = "OpenSSL failed - SSL_load_client_CA_file('" + _tlsOptions.caFile +
                                  "') failed: ";
                         errMsg += ERR_error_string(ssl_err, nullptr);
                     }
                     else
                     {
-                        SSL_CTX_set_client_CA_list(_ssl_context, root_cas);
+                        SSL_CTX_set_client_CA_list(_ssl_context, rootCAs);
                         if (SSL_CTX_load_verify_locations(_ssl_context, root_ca_file, NULL) != 1)
                         {
-                            unsigned long ssl_err = ERR_get_error();
+                            auto ssl_err = ERR_get_error();
                             errMsg = "OpenSSL failed - SSL_CTX_load_verify_locations(\"" +
                                      _tlsOptions.caFile + "\") failed: ";
                             errMsg += ERR_error_string(ssl_err, nullptr);

--- a/ixwebsocket/IXSocketOpenSSL.h
+++ b/ixwebsocket/IXSocketOpenSSL.h
@@ -8,6 +8,7 @@
 
 #include "IXCancellationRequest.h"
 #include "IXSocket.h"
+#include "IXSocketTLSOptions.h"
 #include <mutex>
 #include <openssl/bio.h>
 #include <openssl/conf.h>
@@ -20,7 +21,7 @@ namespace ix
     class SocketOpenSSL final : public Socket
     {
     public:
-        SocketOpenSSL(int fd = -1);
+        SocketOpenSSL(const SocketTLSOptions& tlsOptions, int fd = -1);
         ~SocketOpenSSL();
 
         virtual bool connect(const std::string& host,
@@ -44,6 +45,8 @@ namespace ix
         SSL* _ssl_connection;
         SSL_CTX* _ssl_context;
         const SSL_METHOD* _ssl_method;
+        SocketTLSOptions _tlsOptions;
+
         mutable std::mutex _mutex; // OpenSSL routines are not thread-safe
 
         static std::once_flag _openSSLInitFlag;

--- a/ixwebsocket/IXSocketTLSOptions.cpp
+++ b/ixwebsocket/IXSocketTLSOptions.cpp
@@ -1,0 +1,34 @@
+/*
+ *  IXSocketTLSOptions.h
+ *  Author: Benjamin Sergeant
+ *  Copyright (c) 2017-2018 Machine Zone, Inc. All rights reserved.
+ */
+
+#include <assert.h>
+#include "IXSocketTLSOptions.h"
+
+namespace ix
+{
+
+    SocketTLSOptions::SocketTLSOptions() {
+#ifndef IXWEBSOCKET_USE_TLS
+        assert(false && "To use TLS features the library must be compiled with USE_TLS");
+#endif 
+    }
+
+    bool SocketTLSOptions::isUsingClientCert() const
+    {
+        return !certFile.empty() && !keyFile.empty();
+    }
+
+    bool SocketTLSOptions::isUsingSystemDefaults() const
+    {
+        return caFile == "SYSTEM";
+    }
+
+    bool SocketTLSOptions::isPeerVerifyDisabled() const
+    {
+        return caFile != "NONE";
+    }
+
+} // namespace ix

--- a/ixwebsocket/IXSocketTLSOptions.h
+++ b/ixwebsocket/IXSocketTLSOptions.h
@@ -13,24 +13,24 @@ namespace ix
     struct SocketTLSOptions
     {
         // the certificate presented to peers
-        std::string cert_file;
+        std::string certFile;
         // the key used for signing/encryption
-        std::string key_file;
+        std::string keyFile;
         // the ca certificate (or certificate bundle) file containing 
         // certificates to be trusted by peers; use 'SYSTEM' to
         // leverage the system defaults, use 'NONE' to disable peer verification
-        std::string ca_file = "SYSTEM";
+        std::string caFile = "SYSTEM";
 
         bool isUsingClientCert() const {
-            return !cert_file.empty() && !key_file.empty();
+            return !certFile.empty() && !keyFile.empty();
         }
 
         bool isUsingSystemDefaults() const {
-            return ca_file == "SYSTEM";
+            return caFile == "SYSTEM";
         }
 
         bool isPeerVerifyDisabled() const {
-            return ca_file != "NONE";
+            return caFile != "NONE";
         }
     };
 } // namespace ix

--- a/ixwebsocket/IXSocketTLSOptions.h
+++ b/ixwebsocket/IXSocketTLSOptions.h
@@ -12,6 +12,8 @@ namespace ix
 {
     struct SocketTLSOptions
     {
+        SocketTLSOptions();
+
         // the certificate presented to peers
         std::string certFile;
         // the key used for signing/encryption
@@ -21,16 +23,10 @@ namespace ix
         // leverage the system defaults, use 'NONE' to disable peer verification
         std::string caFile = "SYSTEM";
 
-        bool isUsingClientCert() const {
-            return !certFile.empty() && !keyFile.empty();
-        }
+        bool isUsingClientCert() const;
 
-        bool isUsingSystemDefaults() const {
-            return caFile == "SYSTEM";
-        }
+        bool isUsingSystemDefaults() const;
 
-        bool isPeerVerifyDisabled() const {
-            return caFile != "NONE";
-        }
+        bool isPeerVerifyDisabled() const;
     };
 } // namespace ix

--- a/ixwebsocket/IXSocketTLSOptions.h
+++ b/ixwebsocket/IXSocketTLSOptions.h
@@ -1,0 +1,36 @@
+/*
+ *  IXSocketTLSOptions.h
+ *  Author: Benjamin Sergeant
+ *  Copyright (c) 2017-2018 Machine Zone, Inc. All rights reserved.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace ix
+{
+    struct SocketTLSOptions
+    {
+        // the certificate presented to peers
+        std::string cert_file;
+        // the key used for signing/encryption
+        std::string key_file;
+        // the ca certificate (or certificate bundle) file containing 
+        // certificates to be trusted by peers; use 'SYSTEM' to
+        // leverage the system defaults, use 'NONE' to disable peer verification
+        std::string ca_file = "SYSTEM";
+
+        bool isUsingClientCert() const {
+            return !cert_file.empty() && !key_file.empty();
+        }
+
+        bool isUsingSystemDefaults() const {
+            return ca_file == "SYSTEM";
+        }
+
+        bool isPeerVerifyDisabled() const {
+            return ca_file != "NONE";
+        }
+    };
+} // namespace ix

--- a/ixwebsocket/IXWebSocket.cpp
+++ b/ixwebsocket/IXWebSocket.cpp
@@ -73,6 +73,14 @@ namespace ix
         _perMessageDeflateOptions = perMessageDeflateOptions;
     }
 
+#ifdef IXWEBSOCKET_USE_TLS
+    void WebSocket::setTLSOptions(const SocketTLSOptions& socketTLSOptions)
+    {
+        std::lock_guard<std::mutex> lock(_configMutex);
+        _socketTLSOptions = socketTLSOptions;
+    }
+#endif
+
     const WebSocketPerMessageDeflateOptions& WebSocket::getPerMessageDeflateOptions() const
     {
         std::lock_guard<std::mutex> lock(_configMutex);
@@ -173,6 +181,7 @@ namespace ix
         {
             std::lock_guard<std::mutex> lock(_configMutex);
             _ws.configure(_perMessageDeflateOptions,
+                          _socketTLSOptions,
                           _enablePong,
                           _pingIntervalSecs,
                           _pingTimeoutSecs);
@@ -198,6 +207,7 @@ namespace ix
         {
             std::lock_guard<std::mutex> lock(_configMutex);
             _ws.configure(_perMessageDeflateOptions,
+                          _socketTLSOptions,
                           _enablePong,
                           _pingIntervalSecs,
                           _pingTimeoutSecs);

--- a/ixwebsocket/IXWebSocket.cpp
+++ b/ixwebsocket/IXWebSocket.cpp
@@ -73,13 +73,11 @@ namespace ix
         _perMessageDeflateOptions = perMessageDeflateOptions;
     }
 
-#ifdef IXWEBSOCKET_USE_TLS
     void WebSocket::setTLSOptions(const SocketTLSOptions& socketTLSOptions)
     {
         std::lock_guard<std::mutex> lock(_configMutex);
         _socketTLSOptions = socketTLSOptions;
     }
-#endif
 
     const WebSocketPerMessageDeflateOptions& WebSocket::getPerMessageDeflateOptions() const
     {

--- a/ixwebsocket/IXWebSocket.h
+++ b/ixwebsocket/IXWebSocket.h
@@ -10,6 +10,9 @@
 #pragma once
 
 #include "IXProgressCallback.h"
+#ifdef IXWEBSOCKET_USE_TLS
+#include "IXSocketTLSOptions.h"
+#endif
 #include "IXWebSocketCloseConstants.h"
 #include "IXWebSocketErrorInfo.h"
 #include "IXWebSocketHttpHeaders.h"
@@ -49,6 +52,9 @@ namespace ix
         void setExtraHeaders(const WebSocketHttpHeaders& headers);
         void setPerMessageDeflateOptions(
             const WebSocketPerMessageDeflateOptions& perMessageDeflateOptions);
+#ifdef IXWEBSOCKET_USE_TLS
+        void setTLSOptions(const SocketTLSOptions& socketTLSOptions);
+#endif
         void setHeartBeatPeriod(int heartBeatPeriodSecs);
         void setPingInterval(int pingIntervalSecs); // alias of setHeartBeatPeriod
         void setPingTimeout(int pingTimeoutSecs);
@@ -119,6 +125,9 @@ namespace ix
         WebSocketHttpHeaders _extraHeaders;
 
         WebSocketPerMessageDeflateOptions _perMessageDeflateOptions;
+
+        SocketTLSOptions _socketTLSOptions;
+
         mutable std::mutex _configMutex; // protect all config variables access
 
         OnMessageCallback _onMessageCallback;

--- a/ixwebsocket/IXWebSocket.h
+++ b/ixwebsocket/IXWebSocket.h
@@ -52,9 +52,7 @@ namespace ix
         void setExtraHeaders(const WebSocketHttpHeaders& headers);
         void setPerMessageDeflateOptions(
             const WebSocketPerMessageDeflateOptions& perMessageDeflateOptions);
-#ifdef IXWEBSOCKET_USE_TLS
         void setTLSOptions(const SocketTLSOptions& socketTLSOptions);
-#endif
         void setHeartBeatPeriod(int heartBeatPeriodSecs);
         void setPingInterval(int pingIntervalSecs); // alias of setHeartBeatPeriod
         void setPingTimeout(int pingTimeoutSecs);

--- a/ixwebsocket/IXWebSocketTransport.cpp
+++ b/ixwebsocket/IXWebSocketTransport.cpp
@@ -32,6 +32,7 @@
 // Adapted from https://github.com/dhbaird/easywsclient
 //
 
+#include "IXSocketTLSOptions.h"
 #include "IXWebSocketTransport.h"
 #include "IXWebSocketHandshake.h"
 #include "IXWebSocketHttpHeaders.h"
@@ -103,12 +104,14 @@ namespace ix
     }
 
     void WebSocketTransport::configure(const WebSocketPerMessageDeflateOptions& perMessageDeflateOptions,
+                                       const SocketTLSOptions& socketTLSOptions,
                                        bool enablePong,
                                        int pingIntervalSecs,
                                        int pingTimeoutSecs)
     {
         _perMessageDeflateOptions = perMessageDeflateOptions;
         _enablePerMessageDeflate = _perMessageDeflateOptions.enabled();
+        _socketTLSOptions = socketTLSOptions;
         _enablePong = enablePong;
         _pingIntervalSecs = pingIntervalSecs;
         _pingTimeoutSecs = pingTimeoutSecs;
@@ -147,7 +150,7 @@ namespace ix
 
         std::string errorMsg;
         bool tls = protocol == "wss";
-        _socket = createSocket(tls, errorMsg);
+        _socket = createSocket(tls, errorMsg, _socketTLSOptions);
 
         if (!_socket)
         {

--- a/ixwebsocket/IXWebSocketTransport.h
+++ b/ixwebsocket/IXWebSocketTransport.h
@@ -12,6 +12,7 @@
 
 #include "IXCancellationRequest.h"
 #include "IXProgressCallback.h"
+#include "IXSocketTLSOptions.h"
 #include "IXWebSocketCloseConstants.h"
 #include "IXWebSocketHandshake.h"
 #include "IXWebSocketHttpHeaders.h"
@@ -72,6 +73,7 @@ namespace ix
         ~WebSocketTransport();
 
         void configure(const WebSocketPerMessageDeflateOptions& perMessageDeflateOptions,
+                       const SocketTLSOptions& socketTLSOptions,
                        bool enablePong,
                        int pingIntervalSecs,
                        int pingTimeoutSecs);
@@ -180,6 +182,9 @@ namespace ix
         WebSocketPerMessageDeflate _perMessageDeflate;
         WebSocketPerMessageDeflateOptions _perMessageDeflateOptions;
         std::atomic<bool> _enablePerMessageDeflate;
+
+        // Used to control TLS connection behavior
+        SocketTLSOptions _socketTLSOptions;
 
         // Used to cancel dns lookup + socket connect + http upgrade
         std::atomic<bool> _requestInitCancellation;


### PR DESCRIPTION
This adds a `SocketTLSOptions` type that can be set on clients and servers to configure the certificate used, as well as peer verification options.

