### PR TITLE
Compile bug

### DIFF
--- a/ixwebsocket/IXSocketFactory.cpp
+++ b/ixwebsocket/IXSocketFactory.cpp
@@ -29,7 +29,11 @@ namespace ix
     std::shared_ptr<Socket> createSocket(bool tls,
                                          int fd,
                                          std::string& errorMsg,
+#ifdef IXWEBSOCKET_USE_TLS
                                          const SocketTLSOptions& tlsOptions)
+#else
+                                         const SocketTLSOptions&)
+#endif
     {
         errorMsg.clear();
         std::shared_ptr<Socket> socket;

--- a/ixwebsocket/IXSocketFactory.cpp
+++ b/ixwebsocket/IXSocketFactory.cpp
@@ -29,12 +29,9 @@ namespace ix
     std::shared_ptr<Socket> createSocket(bool tls,
                                          int fd,
                                          std::string& errorMsg,
-#ifdef IXWEBSOCKET_USE_TLS
                                          const SocketTLSOptions& tlsOptions)
-#else
-                                         const SocketTLSOptions&)
-#endif
     {
+        (void) tlsOptions;
         errorMsg.clear();
         std::shared_ptr<Socket> socket;
 

--- a/ixwebsocket/IXWebSocketTransport.cpp
+++ b/ixwebsocket/IXWebSocketTransport.cpp
@@ -543,7 +543,7 @@ namespace ix
             }
 
             // Prevent integer overflow in the next conditional
-            const uint64_t maxFrameSize(uint64_t(1) << 63);
+            const uint64_t maxFrameSize(1ULL << 63);
             if (ws.N > maxFrameSize)
             {
                 return;

--- a/ixwebsocket/IXWebSocketTransport.cpp
+++ b/ixwebsocket/IXWebSocketTransport.cpp
@@ -543,7 +543,7 @@ namespace ix
             }
 
             // Prevent integer overflow in the next conditional
-            const uint64_t maxFrameSize(1 << 63);
+            const uint64_t maxFrameSize(uint64_t(1) << 63);
             if (ws.N > maxFrameSize)
             {
                 return;


### PR DESCRIPTION
1) IXWebSocketTransport: BUG: int type has no warranty of number of bits. It depends on compiler and architecture. In my system (64 bit) is 32 bit.

1 << 63 is bad idea in this case because the final number is 0 by overflow.
The symptom observed is that the server can't receive messages.

2) IXSocketFactory: Compilation Warning: Variable not in use.