### PR TITLE
Make WebsocketServer silent: Remove 'handleConnect() done' info message

### DIFF
--- a/ixwebsocket/IXWebSocketServer.cpp
+++ b/ixwebsocket/IXWebSocketServer.cpp
@@ -106,7 +106,6 @@ namespace ix
             }
         }
 
-        logInfo("WebSocketServer::handleConnection() done");
         connectionState->setTerminated();
     }
 


### PR DESCRIPTION
`IXWebsocketServer.cpp` has a `logInfo()` call, which reports when `handleConnect()` is finished.     There's no way to turn it off, so it makes the server noisy in normal use.

I'm not sure why it is in there, it's the only thing being logged.   So this PR simply removes it.

(Thanks for the nice library!)

