### PR TITLE
Fix bug where setting a ping interval and ping timeout of the same length will cause the socket to timeout immediately.

### DIFF
--- a/ixwebsocket/IXWebSocketTransport.cpp
+++ b/ixwebsocket/IXWebSocketTransport.cpp
@@ -235,7 +235,7 @@ namespace ix
     {
         {
             std::lock_guard<std::mutex> lock(_lastSendPingTimePointMutex);
-            _lastSendPingTimePoint = std::chrono::steady_clock::now();
+            _lastSendPingTimePoint = std::chrono::steady_clock::now() - std::chrono::seconds(_pingIntervalSecs);
         }
         {
             std::lock_guard<std::mutex> lock(_lastReceivePongTimePointMutex);


### PR DESCRIPTION
Set the last send ping time point to _pingIntervalSecs earlier so it fires immediately upon connect. Otherwise if the timeout time is the same, it will not have time to return before the timeout check is run.