### PR TITLE
Implement API for adding custom roots via a string

### DIFF
--- a/ixwebsocket/IXSocketMbedTLS.cpp
+++ b/ixwebsocket/IXSocketMbedTLS.cpp
@@ -103,10 +103,18 @@ namespace ix
             {
                 ; // FIXME
             }
-            else if (mbedtls_x509_crt_parse_file(&_cacert, _tlsOptions.caFile.c_str()) < 0)
-            {
-                errMsg = "Cannot parse CA file '" + _tlsOptions.caFile + "'";
-                return false;
+            else {
+                if (_tlsOptions.isUsingInMemoryCAs()) {
+                    const char *buffer = _tlsOptions.caFile.c_str();
+                    size_t      bufferSize = _tlsOptions.caFile.size() + 1; // Needs to include null terminating character otherwise mbedtls will fail.
+                    if (mbedtls_x509_crt_parse(&_cacert, (const unsigned char *)buffer, bufferSize) < 0) {
+                        errMsg = "Cannot parse CA from memory.";
+                        return false;
+                    }
+                } else if (mbedtls_x509_crt_parse_file(&_cacert, _tlsOptions.caFile.c_str()) < 0) {
+                    errMsg = "Cannot parse CA file '" + _tlsOptions.caFile + "'";
+                    return false;
+                }
             }
 
             mbedtls_ssl_conf_ca_chain(&_conf, &_cacert, NULL);

--- a/ixwebsocket/IXSocketOpenSSL.h
+++ b/ixwebsocket/IXSocketOpenSSL.h
@@ -39,6 +39,7 @@ namespace ix
         void openSSLInitialize();
         std::string getSSLError(int ret);
         SSL_CTX* openSSLCreateContext(std::string& errMsg);
+        bool openSSLAddCARootsFromString(const std::string roots);
         bool openSSLClientHandshake(const std::string& hostname,
                                     std::string& errMsg,
                                     const CancellationRequest& isCancellationRequested);

--- a/ixwebsocket/IXSocketTLSOptions.cpp
+++ b/ixwebsocket/IXSocketTLSOptions.cpp
@@ -13,6 +13,7 @@
 namespace ix
 {
     const char* kTLSCAFileUseSystemDefaults = "SYSTEM";
+    const char* kTLSCAFileUseString = "STRING";
     const char* kTLSCAFileDisableVerify = "NONE";
     const char* kTLSCiphersUseDefault = "DEFAULT";
 
@@ -56,6 +57,11 @@ namespace ix
     bool SocketTLSOptions::isUsingSystemDefaults() const
     {
         return caFile == kTLSCAFileUseSystemDefaults;
+    }
+
+    bool SocketTLSOptions::isUsingStringCAs() const
+    {
+        return caFile == kTLSCAFileUseString;
     }
 
     bool SocketTLSOptions::isPeerVerifyDisabled() const

--- a/ixwebsocket/IXSocketTLSOptions.cpp
+++ b/ixwebsocket/IXSocketTLSOptions.cpp
@@ -13,7 +13,6 @@
 namespace ix
 {
     const char* kTLSCAFileUseSystemDefaults = "SYSTEM";
-    const char* kTLSCAFileUseString = "STRING";
     const char* kTLSCAFileDisableVerify = "NONE";
     const char* kTLSCiphersUseDefault = "DEFAULT";
 
@@ -59,9 +58,8 @@ namespace ix
         return caFile == kTLSCAFileUseSystemDefaults;
     }
 
-    bool SocketTLSOptions::isUsingStringCAs() const
-    {
-        return caFile == kTLSCAFileUseString;
+    bool SocketTLSOptions::isUsingInMemoryCAs() const {
+        return caFile.find("-----BEGIN CERTIFICATE-----") != std::string::npos;
     }
 
     bool SocketTLSOptions::isPeerVerifyDisabled() const

--- a/ixwebsocket/IXSocketTLSOptions.h
+++ b/ixwebsocket/IXSocketTLSOptions.h
@@ -29,6 +29,8 @@ namespace ix
 
         // list of ciphers (rsa, etc...)
         std::string ciphers = "DEFAULT";
+        
+        std::string caCerts = "";
 
         // whether tls is enabled, used for server code
         bool tls = false;
@@ -36,6 +38,8 @@ namespace ix
         bool hasCertAndKey() const;
 
         bool isUsingSystemDefaults() const;
+        
+        bool isUsingStringCAs() const;
 
         bool isPeerVerifyDisabled() const;
 

--- a/ixwebsocket/IXSocketTLSOptions.h
+++ b/ixwebsocket/IXSocketTLSOptions.h
@@ -29,8 +29,6 @@ namespace ix
 
         // list of ciphers (rsa, etc...)
         std::string ciphers = "DEFAULT";
-        
-        std::string caCerts = "";
 
         // whether tls is enabled, used for server code
         bool tls = false;
@@ -39,7 +37,7 @@ namespace ix
 
         bool isUsingSystemDefaults() const;
         
-        bool isUsingStringCAs() const;
+        bool isUsingInMemoryCAs() const;
 
         bool isPeerVerifyDisabled() const;
 


### PR DESCRIPTION
Heyo,

I don't think this is ready to merge, but it's at a point where I'd like some feedback on the API design. I feel good about the implementation in IXSocketOpenSSL, but there isn't really a clean way to specify a string for root CAs via SocketTLSOptions.

I've implemented a quick API on SocketTLSOptions so I can test, but I don't think it's the right way to specify a string of certs. Let me know what you think is the ideal way to specify a string cert in SocketTLSOptions and I can implement and update this PR.

Max