### PR TITLE
add PATCH and add option to enforce a http request body write

### DIFF
--- a/ixwebsocket/IXHttpClient.cpp
+++ b/ixwebsocket/IXHttpClient.cpp
@@ -25,6 +25,7 @@ namespace ix
     const std::string HttpClient::kHead = "HEAD";
     const std::string HttpClient::kDel = "DEL";
     const std::string HttpClient::kPut = "PUT";
+    const std::string HttpClient::kPatch = "PATCH";
 
     HttpClient::HttpClient(bool async)
         : _async(async)
@@ -49,6 +50,9 @@ namespace ix
         _tlsOptions = tlsOptions;
     }
 
+    void setForceBody(bool value) {
+        _forceBody = value;
+    }
     HttpRequestArgsPtr HttpClient::createRequest(const std::string& url, const std::string& verb)
     {
         auto request = std::make_shared<HttpRequestArgs>();
@@ -192,7 +196,7 @@ namespace ix
             ss << "User-Agent: " << userAgent() << "\r\n";
         }
 
-        if (verb == kPost || verb == kPut)
+        if (verb == kPost || verb == kPut || verb == kPatch || _forceBody)
         {
             ss << "Content-Length: " << body.size() << "\r\n";
 

--- a/ixwebsocket/IXHttpClient.h
+++ b/ixwebsocket/IXHttpClient.h
@@ -84,10 +84,10 @@ namespace ix
         void log(const std::string& msg, HttpRequestArgsPtr args);
 
         bool gzipInflate(const std::string& in, std::string& out);
+        bool _forceBody;
 
         // Async API background thread runner
         void run();
-        bool _forceBody;
         // Async API
         bool _async;
         std::queue<std::pair<HttpRequestArgsPtr, OnResponseCallback>> _queue;

--- a/ixwebsocket/IXHttpClient.h
+++ b/ixwebsocket/IXHttpClient.h
@@ -51,7 +51,7 @@ namespace ix
                                 const std::string& body,
                                 HttpRequestArgsPtr args,
                                 int redirects = 0);
-
+        void setForceBody(bool value);
         // Async API
         HttpRequestArgsPtr createRequest(const std::string& url = std::string(),
                                          const std::string& verb = HttpClient::kGet);
@@ -78,6 +78,7 @@ namespace ix
         const static std::string kHead;
         const static std::string kDel;
         const static std::string kPut;
+        const static std::string kPatch;
 
     private:
         void log(const std::string& msg, HttpRequestArgsPtr args);
@@ -86,7 +87,7 @@ namespace ix
 
         // Async API background thread runner
         void run();
-
+        bool _forceBody;
         // Async API
         bool _async;
         std::queue<std::pair<HttpRequestArgsPtr, OnResponseCallback>> _queue;


### PR DESCRIPTION
Discord uses http PATCH for things like message edit which require a body. so i added patch.
Further i know apis also allowing/requiring bodies on other methods such as DELETE, but rather then just pushing a body on every method. i though adding a property to enforce it would be a better approach.