### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Copyright (c) 2018 Machine Zone, Inc. All rights reserved.
 #
 
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.4.1...3.17.2)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake;${CMAKE_MODULE_PATH}")
 
 project(ixwebsocket C CXX)


### PR DESCRIPTION
Using ZLIB_ROOT as described in https://cmake.org/cmake/help/v3.4/module/FindZLIB.html appears not to work because of the policy CMP0074

setting  cmake_minimum_required(VERSION 3.4.1...3.17.2) fix the issue