### PR TITLE
#224: Websocket destructor is not called after closing the connection

### DIFF
--- a/ixwebsocket/IXWebSocketServer.h
+++ b/ixwebsocket/IXWebSocketServer.h
@@ -23,7 +23,7 @@ namespace ix
     {
     public:
         using OnConnectionCallback =
-            std::function<void(std::shared_ptr<WebSocket>, std::shared_ptr<ConnectionState>,
+            std::function<void(std::weak_ptr<WebSocket>, std::shared_ptr<ConnectionState>,
                                std::unique_ptr<ConnectionInfo> connectionInfo)>;
 
         WebSocketServer(int port = SocketServer::kDefaultPort,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,7 +42,7 @@ set (SOURCES
 
   IXSocketTest.cpp
   IXSocketConnectTest.cpp
-  # IXWebSocketLeakTest.cpp # commented until we have a fix for #224
+  IXWebSocketLeakTest.cpp
   IXWebSocketServerTest.cpp
   IXWebSocketTestConnectionDisconnection.cpp
   IXUrlParserTest.cpp

--- a/test/IXWebSocketBroadcastTest.cpp
+++ b/test/IXWebSocketBroadcastTest.cpp
@@ -190,42 +190,47 @@ namespace
         server.setTLSOptions(makeServerTLSOptions(preferTLS));
 
         server.setOnConnectionCallback([&server, &connectionId](
-                                           std::shared_ptr<ix::WebSocket> webSocket,
+                                           std::weak_ptr<ix::WebSocket> webSocket,
                                            std::shared_ptr<ConnectionState> connectionState,
                                            std::unique_ptr<ConnectionInfo> connectionInfo) {
             auto remoteIp = connectionInfo->remoteIp;
-            webSocket->setOnMessageCallback([webSocket, connectionState, remoteIp, &connectionId, &server](
-                                                const ix::WebSocketMessagePtr& msg) {
-                if (msg->type == ix::WebSocketMessageType::Open)
-                {
-                    TLogger() << "New connection";
-                    connectionState->computeId();
-                    TLogger() << "remote ip: " << remoteIp;
-                    TLogger() << "id: " << connectionState->getId();
-                    TLogger() << "Uri: " << msg->openInfo.uri;
-                    TLogger() << "Headers:";
-                    for (auto it : msg->openInfo.headers)
+            auto ws = webSocket.lock();
+            if (ws)
+            {
+                ws->setOnMessageCallback([webSocket, connectionState, remoteIp, &connectionId, &server](
+                                             const ix::WebSocketMessagePtr& msg) {
+                    if (msg->type == ix::WebSocketMessageType::Open)
                     {
-                        TLogger() << it.first << ": " << it.second;
-                    }
-
-                    connectionId = connectionState->getId();
-                }
-                else if (msg->type == ix::WebSocketMessageType::Close)
-                {
-                    TLogger() << "Closed connection";
-                }
-                else if (msg->type == ix::WebSocketMessageType::Message)
-                {
-                    for (auto&& client : server.getClients())
-                    {
-                        if (client != webSocket)
+                        TLogger() << "New connection";
+                        connectionState->computeId();
+                        TLogger() << "remote ip: " << remoteIp;
+                        TLogger() << "id: " << connectionState->getId();
+                        TLogger() << "Uri: " << msg->openInfo.uri;
+                        TLogger() << "Headers:";
+                        for (auto it : msg->openInfo.headers)
                         {
-                            client->send(msg->str, msg->binary);
+                            TLogger() << it.first << ": " << it.second;
+                        }
+
+                        connectionId = connectionState->getId();
+                    }
+                    else if (msg->type == ix::WebSocketMessageType::Close)
+                    {
+                        TLogger() << "Closed connection";
+                    }
+                    else if (msg->type == ix::WebSocketMessageType::Message)
+                    {
+                        auto me = webSocket.lock();
+                        for (auto&& client : server.getClients())
+                        {
+                            if (client != me)
+                            {
+                                client->send(msg->str, msg->binary);
+                            }
                         }
                     }
-                }
-            });
+                });
+            }
         });
 
         auto res = server.listen();

--- a/test/IXWebSocketCloseTest.cpp
+++ b/test/IXWebSocketCloseTest.cpp
@@ -170,43 +170,47 @@ namespace
         // A dev/null server
         server.setOnConnectionCallback(
             [&receivedCloseCode, &receivedCloseReason, &receivedCloseRemote, &mutexWrite](
-                std::shared_ptr<ix::WebSocket> webSocket,
+                std::weak_ptr<ix::WebSocket> webSocket,
                 std::shared_ptr<ConnectionState> connectionState,
                 std::unique_ptr<ConnectionInfo> connectionInfo) {
                 auto remoteIp = connectionInfo->remoteIp;
-                webSocket->setOnMessageCallback([webSocket,
-                                                 connectionState,
-                                                 remoteIp,
-                                                 &receivedCloseCode,
-                                                 &receivedCloseReason,
-                                                 &receivedCloseRemote,
-                                                 &mutexWrite](const ix::WebSocketMessagePtr& msg) {
-                    if (msg->type == ix::WebSocketMessageType::Open)
-                    {
-                        TLogger() << "New server connection";
-                        TLogger() << "remote ip: " << remoteIp;
-                        TLogger() << "id: " << connectionState->getId();
-                        TLogger() << "Uri: " << msg->openInfo.uri;
-                        TLogger() << "Headers:";
-                        for (auto it : msg->openInfo.headers)
+                auto ws = webSocket.lock();
+                if (ws)
+                {
+                    ws->setOnMessageCallback([webSocket,
+                                             connectionState,
+                                             remoteIp,
+                                             &receivedCloseCode,
+                                             &receivedCloseReason,
+                                             &receivedCloseRemote,
+                                             &mutexWrite](const ix::WebSocketMessagePtr& msg) {
+                        if (msg->type == ix::WebSocketMessageType::Open)
                         {
-                            TLogger() << it.first << ": " << it.second;
+                            TLogger() << "New server connection";
+                            TLogger() << "remote ip: " << remoteIp;
+                            TLogger() << "id: " << connectionState->getId();
+                            TLogger() << "Uri: " << msg->openInfo.uri;
+                            TLogger() << "Headers:";
+                            for (auto it : msg->openInfo.headers)
+                            {
+                                TLogger() << it.first << ": " << it.second;
+                            }
                         }
-                    }
-                    else if (msg->type == ix::WebSocketMessageType::Close)
-                    {
-                        std::stringstream ss;
-                        ss << "Server closed connection(" << msg->closeInfo.code << ","
-                           << msg->closeInfo.reason << ")";
-                        log(ss.str());
+                        else if (msg->type == ix::WebSocketMessageType::Close)
+                        {
+                            std::stringstream ss;
+                            ss << "Server closed connection(" << msg->closeInfo.code << ","
+                               << msg->closeInfo.reason << ")";
+                            log(ss.str());
 
-                        std::lock_guard<std::mutex> lck(mutexWrite);
+                            std::lock_guard<std::mutex> lck(mutexWrite);
 
-                        receivedCloseCode = msg->closeInfo.code;
-                        receivedCloseReason = std::string(msg->closeInfo.reason);
-                        receivedCloseRemote = msg->closeInfo.remote;
-                    }
-                });
+                            receivedCloseCode = msg->closeInfo.code;
+                            receivedCloseReason = std::string(msg->closeInfo.reason);
+                            receivedCloseRemote = msg->closeInfo.remote;
+                        }
+                    });
+                }
             });
 
         auto res = server.listen();

--- a/test/IXWebSocketServerTest.cpp
+++ b/test/IXWebSocketServerTest.cpp
@@ -34,42 +34,47 @@ namespace ix
         server.setConnectionStateFactory(factory);
 
         server.setOnConnectionCallback([&server, &connectionId](
-                                           std::shared_ptr<ix::WebSocket> webSocket,
+                                           std::weak_ptr<ix::WebSocket> webSocket,
                                            std::shared_ptr<ConnectionState> connectionState,
                                            std::unique_ptr<ConnectionInfo> connectionInfo) {
             auto remoteIp = connectionInfo->remoteIp;
-            webSocket->setOnMessageCallback([webSocket, connectionState, remoteIp, &connectionId, &server](
-                                                const ix::WebSocketMessagePtr& msg) {
-                if (msg->type == ix::WebSocketMessageType::Open)
-                {
-                    TLogger() << "New connection";
-                    connectionState->computeId();
-                    TLogger() << "remote ip: " << remoteIp;
-                    TLogger() << "id: " << connectionState->getId();
-                    TLogger() << "Uri: " << msg->openInfo.uri;
-                    TLogger() << "Headers:";
-                    for (auto it : msg->openInfo.headers)
+            auto ws = webSocket.lock();
+            if (ws)
+            {
+                ws->setOnMessageCallback([webSocket, connectionState, remoteIp, &connectionId, &server](
+                                            const ix::WebSocketMessagePtr& msg) {
+                    if (msg->type == ix::WebSocketMessageType::Open)
                     {
-                        TLogger() << it.first << ": " << it.second;
-                    }
-
-                    connectionId = connectionState->getId();
-                }
-                else if (msg->type == ix::WebSocketMessageType::Close)
-                {
-                    TLogger() << "Closed connection";
-                }
-                else if (msg->type == ix::WebSocketMessageType::Message)
-                {
-                    for (auto&& client : server.getClients())
-                    {
-                        if (client != webSocket)
+                        TLogger() << "New connection";
+                        connectionState->computeId();
+                        TLogger() << "remote ip: " << remoteIp;
+                        TLogger() << "id: " << connectionState->getId();
+                        TLogger() << "Uri: " << msg->openInfo.uri;
+                        TLogger() << "Headers:";
+                        for (auto it : msg->openInfo.headers)
                         {
-                            client->send(msg->str, msg->binary);
+                            TLogger() << it.first << ": " << it.second;
+                        }
+
+                        connectionId = connectionState->getId();
+                    }
+                    else if (msg->type == ix::WebSocketMessageType::Close)
+                    {
+                        TLogger() << "Closed connection";
+                    }
+                    else if (msg->type == ix::WebSocketMessageType::Message)
+                    {
+                        auto me = webSocket.lock();
+                        for (auto&& client : server.getClients())
+                        {
+                            if (client != me)
+                            {
+                                client->send(msg->str, msg->binary);
+                            }
                         }
                     }
-                }
-            });
+                });
+            }
         });
 
         auto res = server.listen();

--- a/test/IXWebSocketSubProtocolTest.cpp
+++ b/test/IXWebSocketSubProtocolTest.cpp
@@ -17,41 +17,46 @@ using namespace ix;
 bool startServer(ix::WebSocketServer& server, std::string& subProtocols)
 {
     server.setOnConnectionCallback(
-        [&server, &subProtocols](std::shared_ptr<ix::WebSocket> webSocket,
+        [&server, &subProtocols](std::weak_ptr<ix::WebSocket> webSocket,
                                  std::shared_ptr<ConnectionState> connectionState,
                                  std::unique_ptr<ConnectionInfo> connectionInfo) {
             auto remoteIp = connectionInfo->remoteIp;
-            webSocket->setOnMessageCallback([webSocket, connectionState, remoteIp, &server, &subProtocols](
-                                                const ix::WebSocketMessagePtr& msg) {
-                if (msg->type == ix::WebSocketMessageType::Open)
-                {
-                    TLogger() << "New connection";
-                    TLogger() << "remote ip: " << remoteIp;
-                    TLogger() << "id: " << connectionState->getId();
-                    TLogger() << "Uri: " << msg->openInfo.uri;
-                    TLogger() << "Headers:";
-                    for (auto it : msg->openInfo.headers)
+            auto ws = webSocket.lock();
+            if (ws)
+            {
+                ws->setOnMessageCallback([webSocket, connectionState, remoteIp, &server, &subProtocols](
+                    const ix::WebSocketMessagePtr& msg) {
+                    if (msg->type == ix::WebSocketMessageType::Open)
                     {
-                        TLogger() << it.first << ": " << it.second;
-                    }
-
-                    subProtocols = msg->openInfo.headers["Sec-WebSocket-Protocol"];
-                }
-                else if (msg->type == ix::WebSocketMessageType::Close)
-                {
-                    log("Closed connection");
-                }
-                else if (msg->type == ix::WebSocketMessageType::Message)
-                {
-                    for (auto&& client : server.getClients())
-                    {
-                        if (client != webSocket)
+                        TLogger() << "New connection";
+                        TLogger() << "remote ip: " << remoteIp;
+                        TLogger() << "id: " << connectionState->getId();
+                        TLogger() << "Uri: " << msg->openInfo.uri;
+                        TLogger() << "Headers:";
+                        for (auto it : msg->openInfo.headers)
                         {
-                            client->sendBinary(msg->str);
+                            TLogger() << it.first << ": " << it.second;
+                        }
+
+                        subProtocols = msg->openInfo.headers["Sec-WebSocket-Protocol"];
+                    }
+                    else if (msg->type == ix::WebSocketMessageType::Close)
+                    {
+                        log("Closed connection");
+                    }
+                    else if (msg->type == ix::WebSocketMessageType::Message)
+                    {
+                        auto me = webSocket.lock();
+                        for (auto&& client : server.getClients())
+                        {
+                            if (client != me)
+                            {
+                                client->sendBinary(msg->str);
+                            }
                         }
                     }
-                }
-            });
+                });
+            }
         });
 
     auto res = server.listen();

--- a/ws/ws_transfer.cpp
+++ b/ws/ws_transfer.cpp
@@ -19,106 +19,114 @@ namespace ix
         ix::WebSocketServer server(port, hostname);
         server.setTLSOptions(tlsOptions);
 
-        server.setOnConnectionCallback([&server](std::shared_ptr<ix::WebSocket> webSocket,
+        server.setOnConnectionCallback([&server](std::weak_ptr<ix::WebSocket> webSocket,
                                                  std::shared_ptr<ConnectionState> connectionState,
                                                  std::unique_ptr<ConnectionInfo> connectionInfo) {
             auto remoteIp = connectionInfo->remoteIp;
-            webSocket->setOnMessageCallback([webSocket, connectionState, remoteIp, &server](
+            auto ws = webSocket.lock();
+            if (ws)
+            {
+                ws->setOnMessageCallback([webSocket, connectionState, remoteIp, &server](
                                                 const WebSocketMessagePtr& msg) {
-                if (msg->type == ix::WebSocketMessageType::Open)
-                {
-                    spdlog::info("ws_transfer: New connection");
-                    spdlog::info("remote ip: {}", remoteIp);
-                    spdlog::info("id: {}", connectionState->getId());
-                    spdlog::info("Uri: {}", msg->openInfo.uri);
-                    spdlog::info("Headers:");
-                    for (auto it : msg->openInfo.headers)
+                    if (msg->type == ix::WebSocketMessageType::Open)
                     {
-                        spdlog::info("{}: {}", it.first, it.second);
-                    }
-                }
-                else if (msg->type == ix::WebSocketMessageType::Close)
-                {
-                    spdlog::info("ws_transfer: Closed connection: client id {} code {} reason {}",
-                                 connectionState->getId(),
-                                 msg->closeInfo.code,
-                                 msg->closeInfo.reason);
-                    auto remaining = server.getClients().erase(webSocket);
-                    spdlog::info("ws_transfer: {} remaining clients", remaining);
-                }
-                else if (msg->type == ix::WebSocketMessageType::Error)
-                {
-                    std::stringstream ss;
-                    ss << "ws_transfer: Connection error: " << msg->errorInfo.reason << std::endl;
-                    ss << "#retries: " << msg->errorInfo.retries << std::endl;
-                    ss << "Wait time(ms): " << msg->errorInfo.wait_time << std::endl;
-                    ss << "HTTP Status: " << msg->errorInfo.http_status << std::endl;
-                    spdlog::info(ss.str());
-                }
-                else if (msg->type == ix::WebSocketMessageType::Fragment)
-                {
-                    spdlog::info("ws_transfer: Received message fragment ");
-                }
-                else if (msg->type == ix::WebSocketMessageType::Message)
-                {
-                    spdlog::info("ws_transfer: Received {} bytes", msg->wireSize);
-                    size_t receivers = 0;
-                    for (auto&& client : server.getClients())
-                    {
-                        if (client != webSocket)
+                        spdlog::info("ws_transfer: New connection");
+                        spdlog::info("remote ip: {}", remoteIp);
+                        spdlog::info("id: {}", connectionState->getId());
+                        spdlog::info("Uri: {}", msg->openInfo.uri);
+                        spdlog::info("Headers:");
+                        for (auto it : msg->openInfo.headers)
                         {
-                            auto readyState = client->getReadyState();
-                            auto id = connectionState->getId();
-
-                            if (readyState == ReadyState::Open)
-                            {
-                                ++receivers;
-                                client->send(
-                                    msg->str, msg->binary, [&id](int current, int total) -> bool {
-                                        spdlog::info("{}: [client {}]: Step {} out of {}",
-                                                     "ws_transfer",
-                                                     id,
-                                                     current,
-                                                     total);
-                                        return true;
-                                    });
-                                do
-                                {
-                                    size_t bufferedAmount = client->bufferedAmount();
-
-                                    spdlog::info("{}: [client {}]: {} bytes left to send",
-                                                 "ws_transfer",
-                                                 id,
-                                                 bufferedAmount);
-
-                                    std::this_thread::sleep_for(std::chrono::milliseconds(500));
-
-                                } while (client->bufferedAmount() != 0 &&
-                                         client->getReadyState() == ReadyState::Open);
-                            }
-                            else
-                            {
-                                std::string readyStateString =
-                                    readyState == ReadyState::Connecting
-                                        ? "Connecting"
-                                        : readyState == ReadyState::Closing ? "Closing" : "Closed";
-                                size_t bufferedAmount = client->bufferedAmount();
-
-                                spdlog::info(
-                                    "{}: [client {}]: has readystate {} bytes left to be sent {}",
-                                    "ws_transfer",
-                                    id,
-                                    readyStateString,
-                                    bufferedAmount);
-                            }
+                            spdlog::info("{}: {}", it.first, it.second);
                         }
                     }
-                    if (!receivers)
+                    else if (msg->type == ix::WebSocketMessageType::Close)
                     {
-                        spdlog::info("ws_transfer: no remaining receivers");
+                        spdlog::info(
+                            "ws_transfer: Closed connection: client id {} code {} reason {}",
+                            connectionState->getId(),
+                            msg->closeInfo.code,
+                            msg->closeInfo.reason);
+                        auto remaining = server.getClients().erase(webSocket.lock());
+                        spdlog::info("ws_transfer: {} remaining clients", remaining);
                     }
-                }
-            });
+                    else if (msg->type == ix::WebSocketMessageType::Error)
+                    {
+                        std::stringstream ss;
+                        ss << "ws_transfer: Connection error: " << msg->errorInfo.reason
+                           << std::endl;
+                        ss << "#retries: " << msg->errorInfo.retries << std::endl;
+                        ss << "Wait time(ms): " << msg->errorInfo.wait_time << std::endl;
+                        ss << "HTTP Status: " << msg->errorInfo.http_status << std::endl;
+                        spdlog::info(ss.str());
+                    }
+                    else if (msg->type == ix::WebSocketMessageType::Fragment)
+                    {
+                        spdlog::info("ws_transfer: Received message fragment ");
+                    }
+                    else if (msg->type == ix::WebSocketMessageType::Message)
+                    {
+                        spdlog::info("ws_transfer: Received {} bytes", msg->wireSize);
+                        size_t receivers = 0;
+                        auto me = webSocket.lock();
+                        for (auto&& client : server.getClients())
+                        {
+                            if (client != me)
+                            {
+                                auto readyState = client->getReadyState();
+                                auto id = connectionState->getId();
+
+                                if (readyState == ReadyState::Open)
+                                {
+                                    ++receivers;
+                                    client->send(msg->str,
+                                                 msg->binary,
+                                                 [&id](int current, int total) -> bool {
+                                                     spdlog::info(
+                                                         "{}: [client {}]: Step {} out of {}",
+                                                         "ws_transfer",
+                                                         id,
+                                                         current,
+                                                         total);
+                                                     return true;
+                                                 });
+                                    do
+                                    {
+                                        size_t bufferedAmount = client->bufferedAmount();
+
+                                        spdlog::info("{}: [client {}]: {} bytes left to send",
+                                                     "ws_transfer",
+                                                     id,
+                                                     bufferedAmount);
+
+                                        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+                                    } while (client->bufferedAmount() != 0 &&
+                                             client->getReadyState() == ReadyState::Open);
+                                }
+                                else
+                                {
+                                    std::string readyStateString =
+                                        readyState == ReadyState::Connecting ? "Connecting"
+                                        : readyState == ReadyState::Closing  ? "Closing"
+                                                                             : "Closed";
+                                    size_t bufferedAmount = client->bufferedAmount();
+
+                                    spdlog::info("{}: [client {}]: has readystate {} bytes left to be sent {}",
+                                                 "ws_transfer",
+                                                 id,
+                                                 readyStateString,
+                                                 bufferedAmount);
+                                }
+                            }
+                        }
+                        if (!receivers)
+                        {
+                            spdlog::info("ws_transfer: no remaining receivers");
+                        }
+                    }
+                });
+            }
         });
 
         auto res = server.listen();


### PR DESCRIPTION
Solves #224
Use a `weak_ptr` to the websocket in `WebSocketServer::onConnectionCallback` to break the cycle `websocket -> onMessageCallback -> websocket`. This properly deletes the websocket when the connection is closed.

The handling of the `weak_ptr` is rather awkward:

```
server.setOnConnectionCallback([&webSocketPtr](std::weak_ptr<ix::WebSocket> webSocket,
                                                        std::shared_ptr<ConnectionState> connectionState,
                                                        std::unique_ptr<ConnectionInfo> connectionInfo)
{
  if (auto ws = webSocket.lock())
  {
    ws->setOnMessageCallback([webSocket, connectionState](const ix::WebSocketMessagePtr& msg)
    {
      if (msg->type == ix::WebSocketMessageType::Open)
      {
        if (auto ws = webSocket.lock())
        {
          ws->send("hello");
        }
      }
    });
  }
});
```

This solution "works for us", better alternatives would probably need a redesign of the nested `onConnectionCallback/onMessageCallback` mechanism. For example you might consider setting the `onMessageCallback` on a different entity (like the server or something else) and pass the websocket as a parameter, something like

```
server.setOnMessageCallback([](WebSocket& webSocket)
{
  if (msg->type == ix::WebSocketMessageType::Open)
  {
    webSocket.send("hello");
  }
});
```

I did not look at the unit tests (despite the leak test) and build with `cmake -DUSE_TEST=1 -DUSE_WS=1 ..`, so probably I forgot something.

Consider this pull request as work in progress and do with it whatever you want. I don't have a better solution at the moment :(.

