### PR TITLE
Rename HttpResponse's payload to body

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -469,7 +469,7 @@ out = httpClient.post(url, std::string("foo=bar"), args);
 auto statusCode = response->statusCode; // Can be HttpErrorCode::Ok, HttpErrorCode::UrlMalformed, etc...
 auto errorCode = response->errorCode; // 200, 404, etc...
 auto responseHeaders = response->headers; // All the headers in a special case-insensitive unordered_map of (string, string)
-auto payload = response->payload; // All the bytes from the response as an std::string
+auto body = response->body; // All the bytes from the response as an std::string
 auto errorMsg = response->errorMsg; // Descriptive error message in case of failure
 auto uploadSize = response->uploadSize; // Byte count of uploaded data
 auto downloadSize = response->downloadSize; // Byte count of downloaded data

--- a/ixbots/ixbots/IXCobraToSentryBot.cpp
+++ b/ixbots/ixbots/IXCobraToSentryBot.cpp
@@ -41,7 +41,7 @@ namespace ix
                 else
                 {
                     CoreLogger::error("Error sending data to sentry: " + std::to_string(response->statusCode));
-                    CoreLogger::error("Response: " + response->payload);
+                    CoreLogger::error("Response: " + response->body);
 
                     // Error 429 Too Many Requests
                     if (response->statusCode == 429)

--- a/ixwebsocket/IXHttp.cpp
+++ b/ixwebsocket/IXHttp.cpp
@@ -178,7 +178,7 @@ namespace ix
 
         // Write headers
         ss.str("");
-        ss << "Content-Length: " << response->payload.size() << "\r\n";
+        ss << "Content-Length: " << response->body.size() << "\r\n";
         for (auto&& it : response->headers)
         {
             ss << it.first << ": " << it.second << "\r\n";
@@ -190,6 +190,6 @@ namespace ix
             return false;
         }
 
-        return response->payload.empty() ? true : socket->writeBytes(response->payload, nullptr);
+        return response->body.empty() ? true : socket->writeBytes(response->body, nullptr);
     }
 } // namespace ix

--- a/ixwebsocket/IXHttp.h
+++ b/ixwebsocket/IXHttp.h
@@ -39,7 +39,7 @@ namespace ix
         std::string description;
         HttpErrorCode errorCode;
         WebSocketHttpHeaders headers;
-        std::string payload;
+        std::string body;
         std::string errorMsg;
         uint64_t uploadSize;
         uint64_t downloadSize;
@@ -48,7 +48,7 @@ namespace ix
                      const std::string& des = std::string(),
                      const HttpErrorCode& c = HttpErrorCode::Ok,
                      const WebSocketHttpHeaders& h = WebSocketHttpHeaders(),
-                     const std::string& p = std::string(),
+                     const std::string& b = std::string(),
                      const std::string& e = std::string(),
                      uint64_t u = 0,
                      uint64_t d = 0)
@@ -56,7 +56,7 @@ namespace ix
             , description(des)
             , errorCode(c)
             , headers(h)
-            , payload(p)
+            , body(b)
             , errorMsg(e)
             , uploadSize(u)
             , downloadSize(d)

--- a/test/IXHttpServerTest.cpp
+++ b/test/IXHttpServerTest.cpp
@@ -103,11 +103,11 @@ TEST_CASE("http server", "[httpd]")
 
         std::cerr << "Status: " << response->statusCode << std::endl;
         std::cerr << "Error message: " << response->errorMsg << std::endl;
-        std::cerr << "Payload: " << response->payload << std::endl;
+        std::cerr << "Body: " << response->body << std::endl;
 
         REQUIRE(response->errorCode == HttpErrorCode::Ok);
         REQUIRE(response->statusCode == 200);
-        REQUIRE(response->payload == args->body);
+        REQUIRE(response->body == args->body);
 
         server.stop();
     }

--- a/ws/ws.cpp
+++ b/ws/ws.cpp
@@ -1454,14 +1454,14 @@ namespace ix
 
                 spdlog::info("Writing to disk: {}", filename);
                 std::ofstream out(filename);
-                out.write((char*) &response->payload.front(), response->payload.size());
+                out.write((char*) &response->body.front(), response->body.size());
                 out.close();
             }
             else
             {
                 if (response->headers["Content-Type"] != "application/octet-stream")
                 {
-                    spdlog::info("payload: {}", response->payload);
+                    spdlog::info("body: {}", response->body);
                 }
                 else
                 {
@@ -2546,7 +2546,7 @@ namespace ix
 
                     if (response->headers["Content-Type"] != "application/octet-stream")
                     {
-                        spdlog::info("payload: {}", response->payload);
+                        spdlog::info("body: {}", response->body);
                     }
                 }
 
@@ -2554,7 +2554,7 @@ namespace ix
                 {
                     spdlog::error("Error sending data to sentry: {}", response->statusCode);
                     spdlog::error("Status: {}", response->statusCode);
-                    spdlog::error("Response: {}", response->payload);
+                    spdlog::error("Response: {}", response->body);
                 }
                 else
                 {


### PR DESCRIPTION
I think it feels odd/inconsistent using the name `payload` in `ix::HttpResponse`, especially when the name `body` is used in `ix::HttpRequest`. 

Would renaming this be OK? 