### PR TITLE
Fix an issue with disabling zlib and getting linker errors from the http client.

### DIFF
--- a/ixwebsocket/IXHttp.h
+++ b/ixwebsocket/IXHttp.h
@@ -83,8 +83,10 @@ namespace ix
         bool followRedirects = true;
         int maxRedirects = 5;
         bool verbose = false;
+#ifdef IXWEBSOCKET_USE_ZLIB
         bool compress = true;
         bool compressRequest = false;
+#endif
         Logger logger;
         OnProgressCallback onProgressCallback;
     };

--- a/ixwebsocket/IXHttp.h
+++ b/ixwebsocket/IXHttp.h
@@ -83,10 +83,8 @@ namespace ix
         bool followRedirects = true;
         int maxRedirects = 5;
         bool verbose = false;
-#ifdef IXWEBSOCKET_USE_ZLIB
         bool compress = true;
         bool compressRequest = false;
-#endif
         Logger logger;
         OnProgressCallback onProgressCallback;
     };

--- a/ixwebsocket/IXHttpClient.cpp
+++ b/ixwebsocket/IXHttpClient.cpp
@@ -6,9 +6,7 @@
 
 #include "IXHttpClient.h"
 
-#ifdef IXWEBSOCKET_USE_ZLIB
 #include "IXGzipCodec.h"
-#endif
 #include "IXSocketFactory.h"
 #include "IXUrlParser.h"
 #include "IXUserAgent.h"

--- a/ixwebsocket/IXHttpClient.cpp
+++ b/ixwebsocket/IXHttpClient.cpp
@@ -6,7 +6,9 @@
 
 #include "IXHttpClient.h"
 
+#ifdef IXWEBSOCKET_USE_ZLIB
 #include "IXGzipCodec.h"
+#endif
 #include "IXSocketFactory.h"
 #include "IXUrlParser.h"
 #include "IXUserAgent.h"
@@ -204,11 +206,13 @@ namespace ix
         if (verb == kPost || verb == kPut || verb == kPatch || _forceBody)
         {
             // Set request compression header
+#ifdef IXWEBSOCKET_USE_ZLIB
             if (args->compressRequest)
             {
                 ss << "Content-Encoding: gzip"
                    << "\r\n";
             }
+#endif
 
             ss << "Content-Length: " << body.size() << "\r\n";
 
@@ -580,10 +584,12 @@ namespace ix
                 multipartBoundary, httpFormDataParameters, httpParameters);
         }
 
+#ifdef IXWEBSOCKET_USE_ZLIB
         if (args->compressRequest)
         {
             body = gzipCompress(body);
         }
+#endif
 
         return request(url, verb, body, args);
     }


### PR DESCRIPTION
I was running into linker errors when I would disable zlib and try to use the HTTP client. After I looked at them, it looked like it was trying to use zlib to compress requests (only when args->compress was set), this caused linker errors.

I fixed them by adding `#ifdef IXWEBSOCKET_USE_ZLIB` before the if statements and also where you define the `compress` and `compressRequest` fields in the `ix::HttpRequestArgs` struct since they won't be used without zlib.

I tried to follow the same commit message format that I saw you use, in this commit.