### PR TITLE
Always make OpenSSL verify the peer certificate

### DIFF
--- a/ixwebsocket/IXSocketOpenSSL.cpp
+++ b/ixwebsocket/IXSocketOpenSSL.cpp
@@ -503,14 +503,14 @@ namespace ix
                         errMsg += ERR_error_string(sslErr, nullptr);
                         return false;
                     }
-
-                    SSL_CTX_set_verify(
-                        _ssl_context, SSL_VERIFY_PEER, [](int preverify, X509_STORE_CTX*) -> int {
-                            return preverify;
-                        });
-                    SSL_CTX_set_verify_depth(_ssl_context, 4);
                 }
             }
+
+            SSL_CTX_set_verify(
+                _ssl_context, SSL_VERIFY_PEER, [](int preverify, X509_STORE_CTX*) -> int {
+                    return preverify;
+                });
+            SSL_CTX_set_verify_depth(_ssl_context, 4);
         }
         else
         {


### PR DESCRIPTION
**Error description:**

When using an `IXWebSocket` with the default SSL config, the server certificate is not checked. This can be reproduced by setting your system clock to a date that is outside of the certificates begin/end date. The `IXWebSocket` (specifically `IXSocketOpenSSL`) will still happily connect to it. The OpenSSL version used is 0x1010107fL (1.1.1g).

**Fix:**

Always set `SSL_VERIFY_PEER`, unless `_tlsOptions.isPeerVerifyDisabled()` returns `true`.

**Caveat:**

I don't know if this routine is also used for server sockets. In that case there needs to be a special case, because the `IXWebSocketServer` validating a client certificate is probably not desired. Is this a problem?