### PR TITLE
(http server) Do not overwrite response headers with request headers

### DIFF
--- a/ixwebsocket/IXHttpServer.cpp
+++ b/ixwebsocket/IXHttpServer.cpp
@@ -151,7 +151,11 @@ namespace ix
 
                 for (auto&& it : request->headers)
                 {
-                    headers[it.first] = it.second;
+                    //Do not replace our explicitly set server headers with client headers
+                    if(!headers.count(it.first))
+                    {
+                        headers[it.first] = it.second;
+                    }
                 }
 
                 return std::make_shared<HttpResponse>(


### PR DESCRIPTION
When trying to open files served on a local machine with Firefox 87 on Ubuntu 18.04, I discovered a bug where the HttpResponse was overwriting all of its headers with anything in HttpRequest.

In particular this browser had a header `Content-Encoding:` in the request which was eliminating the gzip option specified by the server, but it also doesn't make sense in general to overwrite the response headers with the request headers that have been explicitly set.