### PR TITLE
Fix unsafe calls and safeguard WebSocketMessage

### DIFF
--- a/ixwebsocket/IXWebSocket.cpp
+++ b/ixwebsocket/IXWebSocket.cpp
@@ -15,7 +15,10 @@
 #include <cmath>
 
 
-static const std::string emptyMsg;
+namespace
+{
+    const std::string emptyMsg;
+} // namespace
 
 
 namespace ix

--- a/ixwebsocket/IXWebSocket.cpp
+++ b/ixwebsocket/IXWebSocket.cpp
@@ -15,6 +15,9 @@
 #include <cmath>
 
 
+static const std::string emptyMsg;
+
+
 namespace ix
 {
     OnTrafficTrackerCallback WebSocket::_onTrafficTrackerCallback = nullptr;
@@ -38,7 +41,7 @@ namespace ix
             [this](uint16_t code, const std::string& reason, size_t wireSize, bool remote) {
                 _onMessageCallback(
                     ix::make_unique<WebSocketMessage>(WebSocketMessageType::Close,
-                                                      "",
+                                                      emptyMsg,
                                                       wireSize,
                                                       WebSocketErrorInfo(),
                                                       WebSocketOpenInfo(),
@@ -217,7 +220,7 @@ namespace ix
 
         _onMessageCallback(ix::make_unique<WebSocketMessage>(
             WebSocketMessageType::Open,
-            "",
+            emptyMsg,
             0,
             WebSocketErrorInfo(),
             WebSocketOpenInfo(status.uri, status.headers, status.protocol),
@@ -251,7 +254,7 @@ namespace ix
 
         _onMessageCallback(
             ix::make_unique<WebSocketMessage>(WebSocketMessageType::Open,
-                                              "",
+                                              emptyMsg,
                                               0,
                                               WebSocketErrorInfo(),
                                               WebSocketOpenInfo(status.uri, status.headers),
@@ -338,7 +341,7 @@ namespace ix
                 connectErr.http_status = status.http_status;
 
                 _onMessageCallback(ix::make_unique<WebSocketMessage>(WebSocketMessageType::Error,
-                                                                     "",
+                                                                     emptyMsg,
                                                                      0,
                                                                      connectErr,
                                                                      WebSocketOpenInfo(),

--- a/ixwebsocket/IXWebSocketMessage.h
+++ b/ixwebsocket/IXWebSocketMessage.h
@@ -42,6 +42,18 @@ namespace ix
         {
             ;
         }
+
+        /**
+         * @brief Deleted overload to prevent binding `str` to a temporary, which would cause
+         * undefined behavior since class members don't extend lifetime beyond the constructor call.
+         */
+        WebSocketMessage(WebSocketMessageType t,
+                         std::string&& s,
+                         size_t w,
+                         WebSocketErrorInfo e,
+                         WebSocketOpenInfo o,
+                         WebSocketCloseInfo c,
+                         bool b = false) = delete;
     };
 
     using WebSocketMessagePtr = std::unique_ptr<WebSocketMessage>;


### PR DESCRIPTION
Binding `WebSocketMessage` to a temporary message argument can create undefined behavior. This MR introduces a deleted constructor overload to "absorb" cases where string arguments are temporaries and fixes unsafe calls that were "exposed" by the deleted constructor.