### PR TITLE
Avoid duplicate Accept and User-Agent headers

### DIFF
--- a/ixwebsocket/IXHttpClient.cpp
+++ b/ixwebsocket/IXHttpClient.cpp
@@ -190,14 +190,14 @@ namespace ix
         }
 
         // Set a default Accept header if none is present
-        if (headers.find("Accept") == headers.end())
+        if (args->extraHeaders.find("Accept") == args->extraHeaders.end())
         {
             ss << "Accept: */*"
                << "\r\n";
         }
 
         // Set a default User agent if none is present
-        if (headers.find("User-Agent") == headers.end())
+        if (args->extraHeaders.find("User-Agent") == args->extraHeaders.end())
         {
             ss << "User-Agent: " << userAgent() << "\r\n";
         }


### PR DESCRIPTION
The logic for preventing these duplicate headers was flawed. It was checking the empty response's headers rather than the headers specified in the request.