### PR TITLE
Avoid returning references that are mutex protected

### DIFF
--- a/ixwebsocket/IXWebSocket.cpp
+++ b/ixwebsocket/IXWebSocket.cpp
@@ -41,7 +41,8 @@ namespace ix
         , _pingIntervalSecs(kDefaultPingIntervalSecs)
     {
         _ws.setOnCloseCallback(
-            [this](uint16_t code, const std::string& reason, size_t wireSize, bool remote) {
+            [this](uint16_t code, const std::string& reason, size_t wireSize, bool remote)
+            {
                 _onMessageCallback(
                     ix::make_unique<WebSocketMessage>(WebSocketMessageType::Close,
                                                       emptyMsg,
@@ -75,7 +76,7 @@ namespace ix
         _extraHeaders = headers;
     }
 
-    const std::string& WebSocket::getUrl() const
+    const std::string WebSocket::getUrl() const
     {
         std::lock_guard<std::mutex> lock(_configMutex);
         return _url;
@@ -94,7 +95,7 @@ namespace ix
         _socketTLSOptions = socketTLSOptions;
     }
 
-    const WebSocketPerMessageDeflateOptions& WebSocket::getPerMessageDeflateOptions() const
+    const WebSocketPerMessageDeflateOptions WebSocket::getPerMessageDeflateOptions() const
     {
         std::lock_guard<std::mutex> lock(_configMutex);
         return _perMessageDeflateOptions;
@@ -384,7 +385,8 @@ namespace ix
                 [this](const std::string& msg,
                        size_t wireSize,
                        bool decompressionError,
-                       WebSocketTransport::MessageKind messageKind) {
+                       WebSocketTransport::MessageKind messageKind)
+                {
                     WebSocketMessageType webSocketMessageType;
                     switch (messageKind)
                     {

--- a/ixwebsocket/IXWebSocket.cpp
+++ b/ixwebsocket/IXWebSocket.cpp
@@ -15,7 +15,10 @@
 #include <cmath>
 
 
-static const std::string emptyMsg;
+namespace
+{
+    const std::string emptyMsg;
+} // namespace
 
 
 namespace ix

--- a/ixwebsocket/IXWebSocket.cpp
+++ b/ixwebsocket/IXWebSocket.cpp
@@ -15,6 +15,9 @@
 #include <cmath>
 
 
+static const std::string emptyMsg;
+
+
 namespace ix
 {
     OnTrafficTrackerCallback WebSocket::_onTrafficTrackerCallback = nullptr;
@@ -38,7 +41,7 @@ namespace ix
             [this](uint16_t code, const std::string& reason, size_t wireSize, bool remote) {
                 _onMessageCallback(
                     ix::make_unique<WebSocketMessage>(WebSocketMessageType::Close,
-                                                      "",
+                                                      emptyMsg,
                                                       wireSize,
                                                       WebSocketErrorInfo(),
                                                       WebSocketOpenInfo(),
@@ -217,7 +220,7 @@ namespace ix
 
         _onMessageCallback(ix::make_unique<WebSocketMessage>(
             WebSocketMessageType::Open,
-            "",
+            emptyMsg,
             0,
             WebSocketErrorInfo(),
             WebSocketOpenInfo(status.uri, status.headers, status.protocol),
@@ -251,7 +254,7 @@ namespace ix
 
         _onMessageCallback(
             ix::make_unique<WebSocketMessage>(WebSocketMessageType::Open,
-                                              "",
+                                              emptyMsg,
                                               0,
                                               WebSocketErrorInfo(),
                                               WebSocketOpenInfo(status.uri, status.headers),
@@ -338,7 +341,7 @@ namespace ix
                 connectErr.http_status = status.http_status;
 
                 _onMessageCallback(ix::make_unique<WebSocketMessage>(WebSocketMessageType::Error,
-                                                                     "",
+                                                                     emptyMsg,
                                                                      0,
                                                                      connectErr,
                                                                      WebSocketOpenInfo(),

--- a/ixwebsocket/IXWebSocket.h
+++ b/ixwebsocket/IXWebSocket.h
@@ -92,8 +92,8 @@ namespace ix
         ReadyState getReadyState() const;
         static std::string readyStateToString(ReadyState readyState);
 
-        const std::string& getUrl() const;
-        const WebSocketPerMessageDeflateOptions& getPerMessageDeflateOptions() const;
+        const std::string getUrl() const;
+        const WebSocketPerMessageDeflateOptions getPerMessageDeflateOptions() const;
         int getPingInterval() const;
         size_t bufferedAmount() const;
 

--- a/ixwebsocket/IXWebSocketMessage.h
+++ b/ixwebsocket/IXWebSocketMessage.h
@@ -42,6 +42,18 @@ namespace ix
         {
             ;
         }
+
+        /**
+         * @brief Deleted overload to prevent binding `str` to a temporary, which would cause
+         * undefined behavior since class members don't extend lifetime beyond the constructor call.
+         */
+        WebSocketMessage(WebSocketMessageType t,
+                         std::string&& s,
+                         size_t w,
+                         WebSocketErrorInfo e,
+                         WebSocketOpenInfo o,
+                         WebSocketCloseInfo c,
+                         bool b = false) = delete;
     };
 
     using WebSocketMessagePtr = std::unique_ptr<WebSocketMessage>;

--- a/ixwebsocket/IXWebSocketPerMessageDeflateOptions.cpp
+++ b/ixwebsocket/IXWebSocketPerMessageDeflateOptions.cpp
@@ -14,12 +14,12 @@ namespace ix
 {
     /// Default values as defined in the RFC
     const uint8_t WebSocketPerMessageDeflateOptions::kDefaultServerMaxWindowBits = 15;
-    static const int minServerMaxWindowBits = 8;
-    static const int maxServerMaxWindowBits = 15;
+    static const uint8_t minServerMaxWindowBits = 8;
+    static const uint8_t maxServerMaxWindowBits = 15;
 
     const uint8_t WebSocketPerMessageDeflateOptions::kDefaultClientMaxWindowBits = 15;
-    static const int minClientMaxWindowBits = 8;
-    static const int maxClientMaxWindowBits = 15;
+    static const uint8_t minClientMaxWindowBits = 8;
+    static const uint8_t maxClientMaxWindowBits = 15;
 
     WebSocketPerMessageDeflateOptions::WebSocketPerMessageDeflateOptions(
         bool enabled,
@@ -85,11 +85,7 @@ namespace ix
 
             if (startsWith(token, "server_max_window_bits="))
             {
-                std::string val = token.substr(token.find_last_of("=") + 1);
-                std::stringstream ss;
-                ss << val;
-                int x;
-                ss >> x;
+                uint8_t x = std::stoi(token.substr(token.find_last_of("=") + 1));
 
                 // Sanitize values to be in the proper range [8, 15] in
                 // case a server would give us bogus values
@@ -99,11 +95,7 @@ namespace ix
 
             if (startsWith(token, "client_max_window_bits="))
             {
-                std::string val = token.substr(token.find_last_of("=") + 1);
-                std::stringstream ss;
-                ss << val;
-                int x;
-                ss >> x;
+                uint8_t x = std::stoi(token.substr(token.find_last_of("=") + 1));
 
                 // Sanitize values to be in the proper range [8, 15] in
                 // case a server would give us bogus values

--- a/ixwebsocket/IXWebSocketPerMessageDeflateOptions.h
+++ b/ixwebsocket/IXWebSocketPerMessageDeflateOptions.h
@@ -39,8 +39,8 @@ namespace ix
         bool _enabled;
         bool _clientNoContextTakeover;
         bool _serverNoContextTakeover;
-        int _clientMaxWindowBits;
-        int _serverMaxWindowBits;
+        uint8_t _clientMaxWindowBits;
+        uint8_t _serverMaxWindowBits;
 
         void sanitizeClientMaxWindowBits();
     };


### PR DESCRIPTION
Motivation for this MR #292 
 
 The antipattern of returning references to mutex protected members was removed. Since a caller can hold the reference it would make all class level locking meaningless.
 
 Instead values are returned. The IXWebSocketPerMessageDeflateOptions class was shrunk by 7 bytes (1 padding + 2*3) after changing the int members to the used uint8_t; side effects of that were handled.
 
 An inefficient "string -> int" was replaced by standard library. As seen here http://coliru.stacked-crooked.com/a/46b5990bafb9c626 this gives an order of magnitude better performance.