### PR TITLE
fix compilation under mingw64

### DIFF
--- a/ixwebsocket/IXNetSystem.cpp
+++ b/ixwebsocket/IXNetSystem.cpp
@@ -5,6 +5,8 @@
  */
 
 #include "IXNetSystem.h"
+#include <cstdint>
+#include <cstdio>
 
 namespace ix
 {

--- a/ixwebsocket/IXNetSystem.h
+++ b/ixwebsocket/IXNetSystem.h
@@ -34,8 +34,8 @@
 // Define our own poll on Windows, as a wrapper on top of select
 typedef unsigned long int nfds_t;
 
-// mingw does not know about poll so mock it
-#if defined(__GNUC__)
+// pollfd is not defined by some versions of mingw64 since _WIN32_WINNT is too low
+#if _WIN32_WINNT < 0x0600
 struct pollfd
 {
     int fd;        /* file descriptor */


### PR DESCRIPTION
closes #324

i dug a little deeper and found [why](https://github.com/mingw-w64/mingw-w64/blob/564d8771316bc1836c5e35dae16a5f87467eb310/mingw-w64-headers/include/winsock2.h#L1116) pollfd wasnt being defined, so hopefully this should take care of all situations