### PR TITLE
Fix IXWebSocketMessage.h:35:15: warning: ‘webSocketMessageType’ may b…

### DIFF
--- a/ixwebsocket/IXWebSocket.cpp
+++ b/ixwebsocket/IXWebSocket.cpp
@@ -385,7 +385,7 @@ namespace ix
                        size_t wireSize,
                        bool decompressionError,
                        WebSocketTransport::MessageKind messageKind) {
-                    WebSocketMessageType webSocketMessageType;
+                    WebSocketMessageType webSocketMessageType{WebSocketMessageType::Error};
                     switch (messageKind)
                     {
                         case WebSocketTransport::MessageKind::MSG_TEXT:


### PR DESCRIPTION
Fix a warning :
```cpp
In file included from /home/rpclab/CLionProjects/YAODAQ/build/_deps/ixwebsocket-src/ixwebsocket/IXWebSocket.h:17,
                 from /home/rpclab/CLionProjects/YAODAQ/build/_deps/ixwebsocket-src/ixwebsocket/IXWebSocket.cpp:7:
/home/rpclab/CLionProjects/YAODAQ/build/_deps/ixwebsocket-src/ixwebsocket/IXWebSocketMessage.h: In function ‘ix::WebSocket::run()::<lambda(const string&, size_t, bool, ix::WebSocketTransport::MessageKind)>’:
/home/rpclab/CLionProjects/YAODAQ/build/_deps/ixwebsocket-src/ixwebsocket/IXWebSocketMessage.h:35:15: warning: ‘webSocketMessageType’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   35 |             : type(t)
      |               ^~~~~~~
/home/rpclab/CLionProjects/YAODAQ/build/_deps/ixwebsocket-src/ixwebsocket/IXWebSocket.cpp:388:42: note: ‘webSocketMessageType’ was declared here
  388 |                     WebSocketMessageType webSocketMessageType;
      |                                          ^~~~~~~~~~~~~~~~~~~~

```