### PR TITLE
Allow to cancel asynchronous HTTP requests

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -517,6 +517,9 @@ bool ok = httpClient.performRequest(args, [](const HttpResponsePtr& response)
 );
 
 // ok will be false if your httpClient is not async
+
+// A request in progress can be cancelled by setting the cancel flag. It does nothing if the request already completed.
+args->cancel = true;
 ```
 
 See this [issue](https://github.com/machinezone/IXWebSocket/issues/209) for links about uploading files with HTTP multipart.

--- a/ixwebsocket/IXHttp.h
+++ b/ixwebsocket/IXHttp.h
@@ -8,6 +8,7 @@
 
 #include "IXProgressCallback.h"
 #include "IXWebSocketHttpHeaders.h"
+#include <atomic>
 #include <tuple>
 #include <unordered_map>
 
@@ -30,6 +31,7 @@ namespace ix
         TooManyRedirects = 12,
         ChunkReadError = 13,
         CannotReadBody = 14,
+        Cancelled = 15,
         Invalid = 100
     };
 
@@ -87,6 +89,7 @@ namespace ix
         bool compressRequest = false;
         Logger logger;
         OnProgressCallback onProgressCallback;
+        std::atomic<bool> cancel;
     };
 
     using HttpRequestArgsPtr = std::shared_ptr<HttpRequestArgs>;


### PR DESCRIPTION
Usage:

```cpp
	auto args = this->httpClient.createRequest(url, method);
	httpClient.performRequest(args, ...);
	[...]
	// Oops, we don't actually want to complete the request!
	args->cancel = true;
```