### PR TITLE
Improved compatibility - less painly mingw crossbuild

### DIFF
--- a/ixwebsocket/IXNetSystem.h
+++ b/ixwebsocket/IXNetSystem.h
@@ -12,8 +12,8 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 
-#include <WS2tcpip.h>
-#include <WinSock2.h>
+#include <ws2tcpip.h>
+#include <winsock2.h>
 #include <basetsd.h>
 #include <io.h>
 #include <ws2def.h>

--- a/ixwebsocket/IXSetThreadName.cpp
+++ b/ixwebsocket/IXSetThreadName.cpp
@@ -17,7 +17,7 @@
 
 // Windows
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 namespace ix

--- a/ixwebsocket/IXSocket.h
+++ b/ixwebsocket/IXSocket.h
@@ -13,7 +13,7 @@
 #include <string>
 
 #ifdef _WIN32
-#include <BaseTsd.h>
+#include <basetsd.h>
 typedef SSIZE_T ssize_t;
 #endif
 

--- a/ixwebsocket/IXSocketOpenSSL.cpp
+++ b/ixwebsocket/IXSocketOpenSSL.cpp
@@ -15,7 +15,7 @@
 #include <errno.h>
 #include <vector>
 #ifdef _WIN32
-#include <Shlwapi.h>
+#include <shlwapi.h>
 #else
 #include <fnmatch.h>
 #endif

--- a/ixwebsocket/IXUdpSocket.h
+++ b/ixwebsocket/IXUdpSocket.h
@@ -11,7 +11,7 @@
 #include <string>
 
 #ifdef _WIN32
-#include <BaseTsd.h>
+#include <basetsd.h>
 typedef SSIZE_T ssize_t;
 #endif
 


### PR DESCRIPTION
Hello.
Sorry my English - not native for me.
I'm build this project on ubuntu for windows system with

`svost@svost-VirtualBox:~/src/tmp/IXWebSocket$ x86_64-w64-mingw32-g++ -v
Thread model: posix
gcc version 9.3-posix 20200320 (GCC)`

step 1 build static openssl `CROSS_COMPILE="x86_64-w64-mingw32-" ./Configure mingw64 no-asm no-shared --prefix=/usr/x86_64-w64-mingw32`

step 2 build library `svost@svost-VirtualBox:~/src/tmp$ cmake -DOPENSSL_ROOT_DIR=../openssl-1.1.1m -DWIN32=1 -DMINGW=1 -DWindows=1 -DUSE_ZLIB=0 -DUSE_TLS=1 -DUSE_OPEN_SSL=1 ..`

step 3 build main.cpp and it works `svost@svost-VirtualBox:~/src/tmp$ x86_64-w64-mingw32-g++ --std=c++11 main.cpp -lixwebsocket -I . -L ./build -L ./openssl-1.1.1m -static -static -l kernel32 -l user32 -l gdi32 -l comdlg32 -l winspool -l winmm -l shell32 -l comctl32 -l ole32 -l oleaut32 -l uuid -l rpcrt4 -l advapi32 -l mswsock -l shlwapi -l ixwebsocket -l ssl -l crypto -l ws2_32 -l crypt32`

`c:\MyProjects\TMP>a.exe
ixwebsocket/11.3.2 windows ssl/OpenSSL OpenSSL 1.1.1m  14 Dec 2021
Connecting to wss://echo.websocket.org...
> Connection error: Unable to connect to echo.websocket.org on port 443, error: Connect error: No error
> Connection error: Unable to connect to echo.websocket.org on port 443, error: Connect error: No error
> Connection error: Unable to connect to echo.websocket.org on port 443, error: Connect error: No error
> Connection error: Unable to connect to echo.websocket.org on port 443, error: Connect error: No error
> Connection error: Unable to connect to echo.websocket.org on port 443, error: Connect error: No error
> Connection error: Unable to connect to echo.websocket.org on port 443, error: Connect error: No error
> Connection error: Unable to connect to echo.websocket.org on port 443, error: Connect error: No error
> ^C
c:\MyProjects\TMP>`

At this moment i stucked on correct cmake file, but it works with ugly fix.
```
svost@svost-VirtualBox:~/src/tmp$ diff mod.txt orig.txt
9,22d8
< set(CMAKE_SYSTEM_NAME Windows)
< set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)
<
< # cross compilers to use for C, C++ and Fortran
< set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
< set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
< set(CMAKE_RC_COMPILER ${TOOLCHAIN_PREFIX}-windres)
<
< # target environment on the build host system
< set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
<
< # modify default behavior of FIND_XXX() commands
< set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
<
196,198d181
<
< set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} /home/svost/src/IXWebSocket/openssl-1.1.1m)
< set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} /home/svost/src/IXWebSocket/openssl-1.1.1m/include)
svost@svost-VirtualBox:~/src/tmp$
```

What is your opinion on adding the cross build option in to CMakeLists.txt file for in-box mingw cross build?