### PR TITLE
Include <cerrno> to provide standard error constants

### DIFF
--- a/ixwebsocket/IXNetSystem.h
+++ b/ixwebsocket/IXNetSystem.h
@@ -17,6 +17,7 @@
 #include <basetsd.h>
 #include <io.h>
 #include <ws2def.h>
+#include <cerrno>
 
 #undef EWOULDBLOCK
 #undef EAGAIN


### PR DESCRIPTION
See https://en.cppreference.com/w/cpp/header/cerrno for additional details. Some of used constants are defined in this header.

Inclusion is necessary to avoid these errors:

```
/home/user/IXWebSocket/ixwebsocket/IXNetSystem.cpp:189:30: error: use of undeclared identifier 'EAFNOSUPPORT'
            default: errno = EAFNOSUPPORT; return 0;
                             ^
/home/user/IXWebSocket/ixwebsocket/IXNetSystem.cpp:191:17: error: use of undeclared identifier 'ENOSPC'
        errno = ENOSPC;
                ^
/home/user/IXWebSocket/ixwebsocket/IXNetSystem.cpp:175:25: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long long') to 'int' [-Wshorten-64-to-32]
                    j = strspn(buf + i, ":0");
                      ~ ^~~~~~~~~~~~~~~~~~~~~
/home/user/IXWebSocket/ixwebsocket/IXNetSystem.cpp:234:21: error: use of undeclared identifier 'EAFNOSUPPORT'
            errno = EAFNOSUPPORT;
                    ^
2 warnings and 3 errors generated.
```

This behaviour may be observed with mingw32 and llvm-mingw cross compiling tools.