### PR TITLE
Export symbols into .def files for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,10 +148,29 @@ if (USE_TLS)
     endif()
 endif()
 
-add_library( ixwebsocket
-    ${IXWEBSOCKET_SOURCES}
-    ${IXWEBSOCKET_HEADERS}
-)
+if(BUILD_SHARED_LIBS)
+    # Building shared library
+    
+    if(MSVC)
+        # Workaround for some projects
+        set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    endif()
+
+    add_library( ixwebsocket SHARED
+        ${IXWEBSOCKET_SOURCES}
+        ${IXWEBSOCKET_HEADERS}
+    )
+    
+    # Set library version
+    set_target_properties(ixwebsocket PROPERTIES VERSION 11.3.2)
+
+else()
+    # Static library
+    add_library( ixwebsocket
+        ${IXWEBSOCKET_SOURCES}
+        ${IXWEBSOCKET_HEADERS}
+    )
+endif()
 
 if (USE_TLS)
     target_compile_definitions(ixwebsocket PUBLIC IXWEBSOCKET_USE_TLS)


### PR DESCRIPTION
Fix #335

https://cmake.org/cmake/help/latest/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html