### PR TITLE
Fix #340 "HTTP/1.1 400 Illegal character CNTL=0xf"

### DIFF
--- a/ixwebsocket/IXSocketTLSOptions.cpp
+++ b/ixwebsocket/IXSocketTLSOptions.cpp
@@ -87,7 +87,7 @@ namespace ix
         ss << "  keyFile  = " << keyFile << std::endl;
         ss << "  caFile   = " << caFile << std::endl;
         ss << "  ciphers  = " << ciphers << std::endl;
-        ss << "  ciphers  = " << ciphers << std::endl;
+        ss << "  tls      = " << tls << std::endl;
         return ss.str();
     }
 } // namespace ix

--- a/ixwebsocket/IXWebSocketPerMessageDeflateOptions.cpp
+++ b/ixwebsocket/IXWebSocketPerMessageDeflateOptions.cpp
@@ -127,8 +127,8 @@ namespace ix
         if (_clientNoContextTakeover) ss << "; client_no_context_takeover";
         if (_serverNoContextTakeover) ss << "; server_no_context_takeover";
 
-        ss << "; server_max_window_bits=" << _serverMaxWindowBits;
-        ss << "; client_max_window_bits=" << _clientMaxWindowBits;
+        ss << "; server_max_window_bits=" << static_cast<int>(_serverMaxWindowBits);
+        ss << "; client_max_window_bits=" << static_cast<int>(_clientMaxWindowBits);
 
         ss << "\r\n";
 


### PR DESCRIPTION
If the per message compression is active the websocket client sends an illegal header to the server.

Instead of
`... ; server_max_window_bits=15; client_max_window_bits=15`
the client sends
? ...; server_max_window_bits=\xf; client-max_window_bits=\xf`

This is caused by using uint8_t that is interpreted as character instead of a number when building the headers.

This PR fixes this bug by casting the `uint8_t` to an `int` when building the headers.