### PR TITLE
Fixed missing header for gcc (9.3.0) compilation

### DIFF
--- a/ixwebsocket/IXSelectInterruptEvent.cpp
+++ b/ixwebsocket/IXSelectInterruptEvent.cpp
@@ -8,6 +8,7 @@
 // emulate the interrupt event by using a short timeout with ix::poll() and
 // read from the SelectInterrupt. (see Socket::poll() "Emulation mode")
 //
+#include <algorithm>
 #include "IXSelectInterruptEvent.h"
 
 namespace ix


### PR DESCRIPTION
This PR adds the missing `#include <algorithm>` for IXSelectInterruptEvent.cpp file when compiling under gcc (9.3.0).

gcc (9.3.0) fails to compile with an unknown function std::find() because it was missing the `#include <algorithm>` that seams to be included with other headers on other compiler platforms.