### PR TITLE
Add an alias for ixwebsocket

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,8 @@ target_include_directories(ixwebsocket PUBLIC
 
 set_target_properties(ixwebsocket PROPERTIES PUBLIC_HEADER "${IXWEBSOCKET_HEADERS}")
 
+add_library(ixwebsocket::ixwebsocket ALIAS ixwebsocket)
+
 option(IXWEBSOCKET_INSTALL "Install IXWebSocket" TRUE)
 
 if (IXWEBSOCKET_INSTALL)


### PR DESCRIPTION
Hello, many thanks for your great library

I'm using it with FetchContent and it's working fine but I can only refer to your library with ixwebsocket while on an install based configuration (using `find_package`) the library is accessible with `ixwebsocket::ixwebsocket`.

This PR allows to use `ixwebsocket::ixwebsocket` inn both cases