### PR TITLE
Add support for streaming transfers

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -520,11 +520,21 @@ bool async = true;
 HttpClient httpClient(async);
 auto args = httpClient.createRequest(url, HttpClient::kGet);
 
+// If you define a chunk callback it will be called repeteadly with the
+// incoming data. This allows to process data on the go or write it to disk
+// instead of accumulating the data in memory.
+args.onChunkCallback = [](const std::string& data)
+{
+    // process data
+};
+
 // Push the request to a queue,
 bool ok = httpClient.performRequest(args, [](const HttpResponsePtr& response)
     {
         // This callback execute in a background thread. Make sure you uses appropriate protection such as mutex
         auto statusCode = response->statusCode; // acess results
+
+        // response->body is empty if onChunkCallback was used
     }
 );
 

--- a/ixwebsocket/IXHttp.cpp
+++ b/ixwebsocket/IXHttp.cpp
@@ -149,7 +149,7 @@ namespace ix
                     false, "Error: 'Content-Length' should be a positive integer", httpRequest);
             }
 
-            auto res = socket->readBytes(contentLength, nullptr, isCancellationRequested);
+            auto res = socket->readBytes(contentLength, nullptr, nullptr, isCancellationRequested);
             if (!res.first)
             {
                 return std::make_tuple(

--- a/ixwebsocket/IXHttp.h
+++ b/ixwebsocket/IXHttp.h
@@ -89,6 +89,7 @@ namespace ix
         bool compressRequest = false;
         Logger logger;
         OnProgressCallback onProgressCallback;
+        OnChunkCallback onChunkCallback;
         std::atomic<bool> cancel;
     };
 

--- a/ixwebsocket/IXProgressCallback.h
+++ b/ixwebsocket/IXProgressCallback.h
@@ -7,8 +7,10 @@
 #pragma once
 
 #include <functional>
+#include <string>
 
 namespace ix
 {
     using OnProgressCallback = std::function<bool(int current, int total)>;
+    using OnChunkCallback = std::function<void(const std::string&)>;
 }

--- a/ixwebsocket/IXSocket.h
+++ b/ixwebsocket/IXSocket.h
@@ -69,6 +69,7 @@ namespace ix
         std::pair<bool, std::string> readLine(const CancellationRequest& isCancellationRequested);
         std::pair<bool, std::string> readBytes(size_t length,
                                                const OnProgressCallback& onProgressCallback,
+                                               const OnChunkCallback& onChunkCallback,
                                                const CancellationRequest& isCancellationRequested);
 
         static int getErrno();


### PR DESCRIPTION
This change adds onChunkCallback to the request. If defined it will be called repeatedly with the incoming data. This allows to process data on the go or write it to disk instead of accumulating the data in memory.