### PR TITLE
Fix for MINGW32 and clang on windows (#352)

### DIFF
--- a/ixwebsocket/IXNetSystem.cpp
+++ b/ixwebsocket/IXNetSystem.cpp
@@ -8,6 +8,12 @@
 #include <cstdint>
 #include <cstdio>
 #ifdef _WIN32
+#ifndef EAFNOSUPPORT
+  #define EAFNOSUPPORT 102
+#endif
+#ifndef ENOSPC
+  #define ENOSPC 28
+#endif
 #include <vector>
 #endif
 

--- a/ixwebsocket/IXSocket.h
+++ b/ixwebsocket/IXSocket.h
@@ -14,7 +14,9 @@
 
 #ifdef _WIN32
 #include <basetsd.h>
+#ifdef _MSC_VER
 typedef SSIZE_T ssize_t;
+#endif
 #endif
 
 #include "IXCancellationRequest.h"

--- a/ixwebsocket/IXUdpSocket.h
+++ b/ixwebsocket/IXUdpSocket.h
@@ -12,7 +12,9 @@
 
 #ifdef _WIN32
 #include <basetsd.h>
+#ifdef _MSC_VER
 typedef SSIZE_T ssize_t;
+#endif
 #endif
 
 #include "IXNetSystem.h"


### PR DESCRIPTION
Hi,
Thanks for this nice library.

Using `msys2 github workflow` msys2/setup-msys2@v2 Clang64 and MINGW32(#352) builds are failling.

These PR fix compilation for this workflow. (tests have not been run)