### PR TITLE
Export static symbols when building ws with shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ set( IXWEBSOCKET_HEADERS
     ixwebsocket/IXWebSocketCloseConstants.h
     ixwebsocket/IXWebSocketCloseInfo.h
     ixwebsocket/IXWebSocketErrorInfo.h
+    ixwebsocket/IXWebsocketExport.h
     ixwebsocket/IXWebSocketHandshake.h
     ixwebsocket/IXWebSocketHandshakeKeyGen.h
     ixwebsocket/IXWebSocketHttpHeaders.h
@@ -173,6 +174,10 @@ else()
         ${IXWEBSOCKET_SOURCES}
         ${IXWEBSOCKET_HEADERS}
     )
+
+   if( MSVC )
+        target_compile_definitions(ixwebsocket PUBLIC IXWEBSOCKET_STATIC_DEFINE)
+    endif()
 endif()
 
 if (USE_TLS)
@@ -286,6 +291,7 @@ if (IXWEBSOCKET_INSTALL)
   install(TARGETS ixwebsocket
           EXPORT ixwebsocket
           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
           PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ixwebsocket/
   )
 

--- a/ixwebsocket/IXDNSLookup.h
+++ b/ixwebsocket/IXDNSLookup.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "IXCancellationRequest.h"
+#include "IXWebsocketExport.h"
 #include <atomic>
 #include <memory>
 #include <mutex>
@@ -54,7 +55,7 @@ namespace ix
         std::string _hostname;
         int _port;
         int64_t _wait;
-        const static int64_t kDefaultWait;
+        IXWEBSOCKET_EXPORT const static int64_t kDefaultWait;
 
         struct addrinfo* _res;
         std::mutex _resMutex;

--- a/ixwebsocket/IXHttpClient.h
+++ b/ixwebsocket/IXHttpClient.h
@@ -10,6 +10,7 @@
 #include "IXSocket.h"
 #include "IXSocketTLSOptions.h"
 #include "IXWebSocketHttpHeaders.h"
+#include "IXWebsocketExport.h"
 #include <algorithm>
 #include <atomic>
 #include <condition_variable>
@@ -91,12 +92,12 @@ namespace ix
 
         std::string urlEncode(const std::string& value);
 
-        const static std::string kPost;
-        const static std::string kGet;
-        const static std::string kHead;
-        const static std::string kDelete;
-        const static std::string kPut;
-        const static std::string kPatch;
+        IXWEBSOCKET_EXPORT const static std::string kPost;
+        IXWEBSOCKET_EXPORT const static std::string kGet;
+        IXWEBSOCKET_EXPORT const static std::string kHead;
+        IXWEBSOCKET_EXPORT const static std::string kDelete;
+        IXWEBSOCKET_EXPORT const static std::string kPut;
+        IXWEBSOCKET_EXPORT const static std::string kPatch;
 
     private:
         void log(const std::string& msg, HttpRequestArgsPtr args);

--- a/ixwebsocket/IXHttpServer.h
+++ b/ixwebsocket/IXHttpServer.h
@@ -9,6 +9,7 @@
 #include "IXHttp.h"
 #include "IXSocketServer.h"
 #include "IXWebSocket.h"
+#include "IXWebsocketExport.h"
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -46,7 +47,7 @@ namespace ix
         OnConnectionCallback _onConnectionCallback;
         std::atomic<int> _connectedClientsCount;
 
-        const static int kDefaultTimeoutSecs;
+        IXWEBSOCKET_EXPORT const static int kDefaultTimeoutSecs;
         int _timeoutSecs;
 
         // Methods

--- a/ixwebsocket/IXSocketServer.h
+++ b/ixwebsocket/IXSocketServer.h
@@ -10,6 +10,7 @@
 #include "IXNetSystem.h"
 #include "IXSelectInterrupt.h"
 #include "IXSocketTLSOptions.h"
+#include "IXWebsocketExport.h"
 #include <atomic>
 #include <condition_variable>
 #include <functional>
@@ -48,11 +49,11 @@ namespace ix
         // that inherits from ConnectionState but has its own methods.
         void setConnectionStateFactory(const ConnectionStateFactory& connectionStateFactory);
 
-        const static int kDefaultPort;
-        const static std::string kDefaultHost;
-        const static int kDefaultTcpBacklog;
-        const static size_t kDefaultMaxConnections;
-        const static int kDefaultAddressFamily;
+        IXWEBSOCKET_EXPORT const static int kDefaultPort;
+        IXWEBSOCKET_EXPORT const static std::string kDefaultHost;
+        IXWEBSOCKET_EXPORT const static int kDefaultTcpBacklog;
+        IXWEBSOCKET_EXPORT const static size_t kDefaultMaxConnections;
+        IXWEBSOCKET_EXPORT const static int kDefaultAddressFamily;
 
         void start();
         std::pair<bool, std::string> listen();

--- a/ixwebsocket/IXWebSocketCloseConstants.h
+++ b/ixwebsocket/IXWebSocketCloseConstants.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "IXWebsocketExport.h"
 #include <cstdint>
 #include <string>
 
@@ -13,25 +14,25 @@ namespace ix
 {
     struct WebSocketCloseConstants
     {
-        static const uint16_t kNormalClosureCode;
-        static const uint16_t kInternalErrorCode;
-        static const uint16_t kAbnormalCloseCode;
-        static const uint16_t kProtocolErrorCode;
-        static const uint16_t kNoStatusCodeErrorCode;
-        static const uint16_t kInvalidFramePayloadData;
+        IXWEBSOCKET_EXPORT static const uint16_t kNormalClosureCode;
+        IXWEBSOCKET_EXPORT static const uint16_t kInternalErrorCode;
+        IXWEBSOCKET_EXPORT static const uint16_t kAbnormalCloseCode;
+        IXWEBSOCKET_EXPORT static const uint16_t kProtocolErrorCode;
+        IXWEBSOCKET_EXPORT static const uint16_t kNoStatusCodeErrorCode;
+        IXWEBSOCKET_EXPORT static const uint16_t kInvalidFramePayloadData;
 
-        static const std::string kNormalClosureMessage;
-        static const std::string kInternalErrorMessage;
-        static const std::string kAbnormalCloseMessage;
-        static const std::string kPingTimeoutMessage;
-        static const std::string kProtocolErrorMessage;
-        static const std::string kNoStatusCodeErrorMessage;
-        static const std::string kProtocolErrorReservedBitUsed;
-        static const std::string kProtocolErrorPingPayloadOversized;
-        static const std::string kProtocolErrorCodeControlMessageFragmented;
-        static const std::string kProtocolErrorCodeDataOpcodeOutOfSequence;
-        static const std::string kProtocolErrorCodeContinuationOpCodeOutOfSequence;
-        static const std::string kInvalidFramePayloadDataMessage;
-        static const std::string kInvalidCloseCodeMessage;
+        IXWEBSOCKET_EXPORT static const std::string kNormalClosureMessage;
+        IXWEBSOCKET_EXPORT static const std::string kInternalErrorMessage;
+        IXWEBSOCKET_EXPORT static const std::string kAbnormalCloseMessage;
+        IXWEBSOCKET_EXPORT static const std::string kPingTimeoutMessage;
+        IXWEBSOCKET_EXPORT static const std::string kProtocolErrorMessage;
+        IXWEBSOCKET_EXPORT static const std::string kNoStatusCodeErrorMessage;
+        IXWEBSOCKET_EXPORT static const std::string kProtocolErrorReservedBitUsed;
+        IXWEBSOCKET_EXPORT static const std::string kProtocolErrorPingPayloadOversized;
+        IXWEBSOCKET_EXPORT static const std::string kProtocolErrorCodeControlMessageFragmented;
+        IXWEBSOCKET_EXPORT static const std::string kProtocolErrorCodeDataOpcodeOutOfSequence;
+        IXWEBSOCKET_EXPORT static const std::string kProtocolErrorCodeContinuationOpCodeOutOfSequence;
+        IXWEBSOCKET_EXPORT static const std::string kInvalidFramePayloadDataMessage;
+        IXWEBSOCKET_EXPORT static const std::string kInvalidCloseCodeMessage;
     };
 } // namespace ix

--- a/ixwebsocket/IXWebSocketServer.h
+++ b/ixwebsocket/IXWebSocketServer.h
@@ -8,6 +8,7 @@
 
 #include "IXSocketServer.h"
 #include "IXWebSocket.h"
+#include "IXWebsocketExport.h"
 #include <condition_variable>
 #include <functional>
 #include <memory>
@@ -50,7 +51,7 @@ namespace ix
         void makeBroadcastServer();
         bool listenAndStart();
 
-        const static int kDefaultHandShakeTimeoutSecs;
+        IXWEBSOCKET_EXPORT const static int kDefaultHandShakeTimeoutSecs;
 
         int getHandshakeTimeoutSecs();
         bool isPongEnabled();
@@ -67,7 +68,7 @@ namespace ix
         std::mutex _clientsMutex;
         std::set<std::shared_ptr<WebSocket>> _clients;
 
-        const static bool kDefaultEnablePong;
+        IXWEBSOCKET_EXPORT const static bool kDefaultEnablePong;
 
         // Methods
         virtual void handleConnection(std::unique_ptr<Socket> socket,

--- a/ixwebsocket/IXWebsocketExport.h
+++ b/ixwebsocket/IXWebsocketExport.h
@@ -1,0 +1,33 @@
+#ifndef IXWEBSOCKET_EXPORT_H
+#define IXWEBSOCKET_EXPORT_H
+
+#ifdef _WIN32
+
+#ifdef IXWEBSOCKET_STATIC_DEFINE 
+   /* Building and using static library */
+#  define IXWEBSOCKET_EXPORT
+#  define IXWEBSOCKET_NO_EXPORT
+#else
+#  ifndef IXWEBSOCKET_EXPORT
+#    ifdef ixwebsocket_EXPORTS /* Comes from cmake, documented in DEFINE_SYMBOL */
+       /* Building dynamic library */
+#      define IXWEBSOCKET_EXPORT __declspec(dllexport)
+#    else
+        /* Using dynamic library */
+#      define IXWEBSOCKET_EXPORT __declspec(dllimport)
+#    endif
+#  endif
+
+#  ifndef IXWEBSOCKET_NO_EXPORT
+#    define IXWEBSOCKET_NO_EXPORT 
+#  endif
+#endif
+
+#else /* _WIN32 */
+
+#  define IXWEBSOCKET_EXPORT
+#  define IXWEBSOCKET_NO_EXPORT
+
+#endif /* _WIN32 */
+
+#endif /* IXWEBSOCKET_EXPORT_H */


### PR DESCRIPTION
CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS from f53b2f8 doesn't export static class members, so when building ws.exe linked against shared ixwebsocket library VS displays errors 'LNK2019 symbol not found'

the solution:
define IXWEBSOCKET_EXPORT to __declspec(dllexport) when building windows dynamic library, to __declspec(dllimport) when using it, to nothing in other cases (static or not windows). then apply this define to all the static members in all .h files
like `IXWEBSOCKET_EXPORT const static bool kDefaultEnablePong;`