### PR TITLE
vcpkg zlib dep fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,11 +234,7 @@ endif()
 option(USE_ZLIB "Enable zlib support" TRUE)
 
 if (USE_ZLIB)
-  # This ZLIB_FOUND check is to help find a cmake manually configured zlib
-  if (NOT ZLIB_FOUND)
-    find_package(ZLIB REQUIRED)
-  endif()
-  target_include_directories(ixwebsocket PUBLIC $<BUILD_INTERFACE:${ZLIB_INCLUDE_DIRS}>)
+  find_package(ZLIB REQUIRED)
   target_link_libraries(ixwebsocket PRIVATE ZLIB::ZLIB)
 
   target_compile_definitions(ixwebsocket PUBLIC IXWEBSOCKET_USE_ZLIB)
@@ -289,10 +285,18 @@ if (IXWEBSOCKET_INSTALL)
           PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ixwebsocket/
   )
 
+  file(WRITE "${CMAKE_INSTALL_PREFIX}/share/ixwebsocket/ixwebsocket-config.cmake"
+[[include(CMakeFindDependencyMacro)
+find_dependency(ZLIB)
+
+include("${CMAKE_CURRENT_LIST_DIR}/ixwebsocket-targets.cmake")]]
+  )        
+  
   install(EXPORT ixwebsocket
-          FILE ixwebsocket-config.cmake
+          FILE ixwebsocket-targets.cmake
           NAMESPACE ixwebsocket::
-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ixwebsocket)
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ixwebsocket
+  )
 endif()
 
 if (USE_WS OR USE_TEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,12 +285,8 @@ if (IXWEBSOCKET_INSTALL)
           PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ixwebsocket/
   )
 
-  file(WRITE "${CMAKE_INSTALL_PREFIX}/share/ixwebsocket/ixwebsocket-config.cmake"
-[[include(CMakeFindDependencyMacro)
-find_dependency(ZLIB)
-
-include("${CMAKE_CURRENT_LIST_DIR}/ixwebsocket-targets.cmake")]]
-  )        
+  configure_file("${CMAKE_CURRENT_LIST_DIR}/ixwebsocket-config.cmake.in" "${CMAKE_BINARY_DIR}/ixwebsocket-config.cmake" @ONLY)
+  install(FILES "${CMAKE_BINARY_DIR}/ixwebsocket-config.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/ixwebsocket")
   
   install(EXPORT ixwebsocket
           FILE ixwebsocket-targets.cmake

--- a/ixwebsocket-config.cmake.in
+++ b/ixwebsocket-config.cmake.in
@@ -1,0 +1,9 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+if（@USE_ZLIB@）
+  find_dependency(ZLIB)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/ixwebsocket-targets.cmake")


### PR DESCRIPTION
Fix https://github.com/machinezone/IXWebSocket/issues/382

Add ixwebsocket-config.cmake and ixwebsocket-targets.cmake.

Verified with vcpkg, the target ZLIB::ZLIB could be found successfully.