### PR TITLE
Fix `Sec-WebSocket-Key` to contain valid Base64.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ set( IXWEBSOCKET_SOURCES
 )
 
 set( IXWEBSOCKET_HEADERS
+    ixwebsocket/IXBase64.h
     ixwebsocket/IXBench.h
     ixwebsocket/IXCancellationRequest.h
     ixwebsocket/IXConnectionState.h

--- a/ixwebsocket/IXBase64.h
+++ b/ixwebsocket/IXBase64.h
@@ -1,0 +1,124 @@
+#ifndef _MACARON_BASE64_H_
+#define _MACARON_BASE64_H_
+
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2016 tomykaira
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <string>
+
+namespace macaron {
+
+class Base64 {
+ public:
+
+  static std::string Encode(const std::string data) {
+    static constexpr char sEncodingTable[] = {
+      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
+      'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+      'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
+      'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+      'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
+      'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+      'w', 'x', 'y', 'z', '0', '1', '2', '3',
+      '4', '5', '6', '7', '8', '9', '+', '/'
+    };
+
+    size_t in_len = data.size();
+    size_t out_len = 4 * ((in_len + 2) / 3);
+    std::string ret(out_len, '\0');
+    size_t i;
+    char *p = const_cast<char*>(ret.c_str());
+
+    for (i = 0; i < in_len - 2; i += 3) {
+      *p++ = sEncodingTable[(data[i] >> 2) & 0x3F];
+      *p++ = sEncodingTable[((data[i] & 0x3) << 4) | ((int) (data[i + 1] & 0xF0) >> 4)];
+      *p++ = sEncodingTable[((data[i + 1] & 0xF) << 2) | ((int) (data[i + 2] & 0xC0) >> 6)];
+      *p++ = sEncodingTable[data[i + 2] & 0x3F];
+    }
+    if (i < in_len) {
+      *p++ = sEncodingTable[(data[i] >> 2) & 0x3F];
+      if (i == (in_len - 1)) {
+        *p++ = sEncodingTable[((data[i] & 0x3) << 4)];
+        *p++ = '=';
+      }
+      else {
+        *p++ = sEncodingTable[((data[i] & 0x3) << 4) | ((int) (data[i + 1] & 0xF0) >> 4)];
+        *p++ = sEncodingTable[((data[i + 1] & 0xF) << 2)];
+      }
+      *p++ = '=';
+    }
+
+    return ret;
+  }
+
+  static std::string Decode(const std::string& input, std::string& out) {
+    static constexpr unsigned char kDecodingTable[] = {
+      64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+      64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+      64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63,
+      52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64,
+      64,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+      15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64, 64,
+      64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+      41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64, 64, 64,
+      64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+      64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+      64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+      64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+      64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+      64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+      64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+      64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64
+    };
+
+    size_t in_len = input.size();
+    if (in_len % 4 != 0) return "Input data size is not a multiple of 4";
+
+    size_t out_len = in_len / 4 * 3;
+    if (input[in_len - 1] == '=') out_len--;
+    if (input[in_len - 2] == '=') out_len--;
+
+    out.resize(out_len);
+
+    for (size_t i = 0, j = 0; i < in_len;) {
+      uint32_t a = input[i] == '=' ? 0 & i++ : kDecodingTable[static_cast<int>(input[i++])];
+      uint32_t b = input[i] == '=' ? 0 & i++ : kDecodingTable[static_cast<int>(input[i++])];
+      uint32_t c = input[i] == '=' ? 0 & i++ : kDecodingTable[static_cast<int>(input[i++])];
+      uint32_t d = input[i] == '=' ? 0 & i++ : kDecodingTable[static_cast<int>(input[i++])];
+
+      uint32_t triple = (a << 3 * 6) + (b << 2 * 6) + (c << 1 * 6) + (d << 0 * 6);
+
+      if (j < out_len) out[j++] = (triple >> 2 * 8) & 0xFF;
+      if (j < out_len) out[j++] = (triple >> 1 * 8) & 0xFF;
+      if (j < out_len) out[j++] = (triple >> 0 * 8) & 0xFF;
+    }
+
+    return "";
+  }
+
+};
+
+}
+
+#endif /* _MACARON_BASE64_H_ */

--- a/ixwebsocket/IXWebSocketHandshake.cpp
+++ b/ixwebsocket/IXWebSocketHandshake.cpp
@@ -6,6 +6,7 @@
 
 #include "IXWebSocketHandshake.h"
 
+#include "IXBase64.h"
 #include "IXHttp.h"
 #include "IXSocketConnect.h"
 #include "IXStrCaseCompare.h"
@@ -16,7 +17,6 @@
 #include <iostream>
 #include <random>
 #include <sstream>
-
 
 namespace ix
 {
@@ -106,15 +106,10 @@ namespace ix
             return WebSocketInitResult(false, 0, ss.str());
         }
 
-        //
-        // Generate a random 24 bytes string which looks like it is base64 encoded
-        // y3JJHMbDL1EzLkh9GBhXDw==
-        // 0cb3Vd9HkbpVVumoS3Noka==
+        // Generate a random 16 bytes string and base64 encode it.
         //
         // See https://stackoverflow.com/questions/18265128/what-is-sec-websocket-key-for
-        //
-        std::string secWebSocketKey = genRandomString(22);
-        secWebSocketKey += "==";
+        std::string secWebSocketKey = macaron::Base64::Encode(genRandomString(16));
 
         std::stringstream ss;
         ss << "GET " << path << " HTTP/1.1\r\n";


### PR DESCRIPTION
The generated header only "looked like" Base64, but if the other side actually tried to decode it as such, it could fail. This change fixes that to always generate a valid Base64 value.

This adds external code to do the base64 encoding. Not sure where you'd like to locate that inside the source tree, happy to change that to a different location, just let me know.