### PR TITLE
Fix spelling mistake in docs

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -54,7 +54,7 @@ To use the installed package within a cmake project, use the following:
  # include headers
  include_directories(${IXWEBSOCKET_INCLUDE_DIR})
  # ...
- target_link_libraries(${PROJECT_NAME} ... ${IXWEBSOCKET_LIBRARY}) # Cmake will automatically fail the generation if the lib was not found, i.e is set to NOTFOUNS
+ target_link_libraries(${PROJECT_NAME} ... ${IXWEBSOCKET_LIBRARY}) # Cmake will automatically fail the generation if the lib was not found, i.e is set to NOTFOUND
 
 ```
 


### PR DESCRIPTION
I am really new to CMake and C++ and I am no expert but I think it should say NOTFOUND instead of NOTFOUNS.

(Bit of a side note which has nothing to do with this pull request but I thought I might as well mention, I also installed IXWebSocket using vcpkg and want to use it in a CMake project but IXWEBSOCKET_INCLUDE_DIR and IXWEBSOCKET_LIBRARY are both NOTFOUND)