### PR TITLE
add Content-Type support

### DIFF
--- a/ixwebsocket/IXHttpServer.cpp
+++ b/ixwebsocket/IXHttpServer.cpp
@@ -40,6 +40,29 @@ namespace
         auto vec = res.second;
         return std::make_pair(res.first, std::string(vec.begin(), vec.end()));
     }
+
+    std::string response_head_file(const std::string& file_name){
+
+        if (std::string::npos != file_name.find(".html") || std::string::npos != file_name.find(".htm"))
+            return "text/html";
+        else if (std::string::npos != file_name.find(".css"))
+            return "text/css";
+        else if (std::string::npos != file_name.find(".js") || std::string::npos != file_name.find(".mjs"))
+            return "application/x-javascript";
+        else if (std::string::npos != file_name.find(".ico"))
+            return "image/x-icon";
+        else if (std::string::npos != file_name.find(".png"))
+            return "image/png";
+        else if (std::string::npos != file_name.find(".jpg") || std::string::npos != file_name.find(".jpeg"))
+            return "image/jpeg";
+        else if (std::string::npos != file_name.find(".gif"))
+            return "image/gif";
+        else if (std::string::npos != file_name.find(".svg"))
+            return "image/svg+xml";
+        else
+            return "application/octet-stream";
+    }
+
 } // namespace
 
 namespace ix
@@ -117,6 +140,7 @@ namespace ix
 
                 WebSocketHttpHeaders headers;
                 headers["Server"] = userAgent();
+                headers["Content-Type"] = response_head_file(uri);
 
                 std::string path("." + uri);
                 auto res = readAsString(path);


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/54659396/180729936-be71817d-df6e-4a2b-a679-1dbc096b342a.png)

![image](https://user-images.githubusercontent.com/54659396/180729720-50ba838a-b572-466b-90e6-c3b1dfdc0bd9.png)

![image](https://user-images.githubusercontent.com/54659396/180730192-2d0512c0-cd31-4bd2-ad82-3ba33811ee16.png)

The old version of `IXWebSocket` did not correctly handle the front-end static file type, causing the front-end page rendering to fail.

The browser needs to recognize the `Content-Type` parameter to determine the file type for rendering, so it is necessary to manually declare the `Content-Type` parameter.