### PR TITLE
Prevent deadlock when the server is stopping

### DIFF
--- a/ixwebsocket/IXSocketServer.h
+++ b/ixwebsocket/IXSocketServer.h
@@ -126,5 +126,6 @@ namespace ix
         // as a connection
         std::condition_variable _conditionVariableGC;
         std::mutex _conditionVariableMutexGC;
+        bool _canContinueGC{ false };
     };
 } // namespace ix


### PR DESCRIPTION
During my tests, I like to start and stop a WebSockets server inside an infinite loop. However, sometimes the loop stops.

I think the problem lies in `_conditionVariableGC`. We use this condition variable to notify the `runGC` thread that something has to be "garbage collected". I think the deadlock happens when we notify the condition variable when the `runGC` is not yet waiting for the condition variable. To prevent this, I use the boolean member `_canContinueGC` to "buffer" the notification. If we want to notify `runGC` while it's not waiting, we can just set `_canContinueGC` to true and `runGC` will know that we called `notify_one`. After `runGC` has checked `_canContinueGC`, it resets it to `false`.

You can easily reproduce the deadlock with this code:
```cpp
int port = getFreePort();
int count = 0;
while(true) {
    std::cout << count++ << std::endl;
    ix::WebSocketServer server(port);
    REQUIRE(server.listen().first);
    server.start();
}
```