### PR TITLE
HTTP should contain port in 'Host' header

### DIFF
--- a/ixwebsocket/IXHttpClient.cpp
+++ b/ixwebsocket/IXHttpClient.cpp
@@ -139,8 +139,9 @@ namespace ix
 
         std::string protocol, host, path, query;
         int port;
+        bool isProtocolDefaultPort;
 
-        if (!UrlParser::parse(url, protocol, host, path, query, port))
+        if (!UrlParser::parse(url, protocol, host, path, query, port, isProtocolDefaultPort))
         {
             std::stringstream ss;
             ss << "Cannot parse url: " << url;
@@ -173,7 +174,12 @@ namespace ix
         // Build request string
         std::stringstream ss;
         ss << verb << " " << path << " HTTP/1.1\r\n";
-        ss << "Host: " << host << "\r\n";
+        ss << "Host: " << host;
+        if (!isProtocolDefaultPort)
+        {
+            ss << ":" << port;
+        }
+        ss << "\r\n";
 
 #ifdef IXWEBSOCKET_USE_ZLIB
         if (args->compress && !args->onChunkCallback)

--- a/ixwebsocket/IXUrlParser.cpp
+++ b/ixwebsocket/IXUrlParser.cpp
@@ -333,6 +333,19 @@ namespace
 
         return Result;
     }
+
+    int getProtocolPort(const std::string& protocol)
+    {
+        if (protocol == "ws" || protocol == "http")
+        {
+            return 80;
+        }
+        else if (protocol == "wss" || protocol == "https")
+        {
+            return 443;
+        }
+        return -1;
+    }
 } // namespace
 
 namespace ix
@@ -343,6 +356,18 @@ namespace ix
                           std::string& path,
                           std::string& query,
                           int& port)
+    {
+        bool isProtocolDefaultPort;
+        return parse(url, protocol, host, path, query, port, isProtocolDefaultPort);
+    }
+
+    bool UrlParser::parse(const std::string& url,
+                              std::string& protocol,
+                              std::string& host,
+                              std::string& path,
+                              std::string& query,
+                              int& port,
+                              bool& isProtocolDefaultPort)
     {
         clParseURL res = clParseURL::ParseURL(url);
 
@@ -356,23 +381,12 @@ namespace ix
         path = res.m_Path;
         query = res.m_Query;
 
+        const auto protocolPort = getProtocolPort(protocol);
         if (!res.GetPort(&port))
         {
-            if (protocol == "ws" || protocol == "http")
-            {
-                port = 80;
-            }
-            else if (protocol == "wss" || protocol == "https")
-            {
-                port = 443;
-            }
-            else
-            {
-                // Invalid protocol. Should be caught by regex check
-                // but this missing branch trigger cpplint linter.
-                return false;
-            }
+            port = protocolPort;
         }
+        isProtocolDefaultPort = port == protocolPort;
 
         if (path.empty())
         {

--- a/ixwebsocket/IXUrlParser.h
+++ b/ixwebsocket/IXUrlParser.h
@@ -19,5 +19,13 @@ namespace ix
                           std::string& path,
                           std::string& query,
                           int& port);
+
+        static bool parse(const std::string& url,
+                          std::string& protocol,
+                          std::string& host,
+                          std::string& path,
+                          std::string& query,
+                          int& port,
+                          bool& isProtocolDefaultPort);
     };
 } // namespace ix


### PR DESCRIPTION
For connection like "http://localhost:8180/" we need send the host name with the port. For more info see https://www.rfc-editor.org/rfc/rfc9110.html#name-host-and-authority