### PR TITLE
fix incorrect closures with code 1011 Internal error

### DIFF
--- a/ixwebsocket/IXWebSocketTransport.cpp
+++ b/ixwebsocket/IXWebSocketTransport.cpp
@@ -700,6 +700,7 @@ namespace ix
                 if (_readyState != ReadyState::CLOSING)
                 {
                     // send back the CLOSE frame
+                    setReadyState(ReadyState::CLOSING);
                     sendCloseFrame(code, reason);
 
                     wakeUpFromPoll(SelectInterrupt::kCloseRequest);
@@ -1072,7 +1073,10 @@ namespace ix
             else if (ret <= 0)
             {
                 closeSocket();
-                setReadyState(ReadyState::CLOSED);
+                if (_readyState != ReadyState::CLOSING)
+                {
+                    setReadyState(ReadyState::CLOSED);
+                }
                 return false;
             }
             else

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,14 +24,13 @@ set (TEST_TARGET_NAMES
   # IXWebSocketBroadcastTest ## FIXME was depending on cobra / take a broadcast server from ws
   IXStrCaseCompareTest
   IXExponentialBackoffTest
+  IXWebSocketCloseTest
 )
 
 # Some unittest don't work on windows yet
 # Windows without TLS does not have hmac yet
 if (UNIX)
   list(APPEND TEST_TARGET_NAMES
-    IXWebSocketCloseTest
-
     # Fail on Windows in CI probably because the pathing is wrong and
     # some resource files cannot be found
     IXHttpServerTest


### PR DESCRIPTION
closes #417

to re-summarize:

if a websocket server sends a close and immediately drops the connection, then ixwebsocket will close with "1011 Internal error" since it fails to reply with a close frame of its own. im not super sure how the connection is closing that causes it to error and im struggling to replicate it myself, but the code in the issue still causes it. [this](https://github.com/openssl/openssl/blob/19cc035b6c6f2283573d29c7ea7f7d675cf750ce/ssl/record/rec_layer_s3.c#L320-L321) is where openssl errors, but it happens with mbedtls as well

https://github.com/machinezone/IXWebSocket/blob/dc7b986e1092e59195085b708033723f4912b98f/ixwebsocket/IXWebSocketTransport.cpp#L699-L709
https://github.com/machinezone/IXWebSocket/blob/dc7b986e1092e59195085b708033723f4912b98f/ixwebsocket/IXWebSocketTransport.cpp#L1072-L1077

this pr makes it so the websocket goes into CLOSING just before replying, and checking if the state is CLOSING before trying to close again

some other things worth considering:
* would `IXWebSocket::close` still work if the send failed?
* the close reason seems to sometimes be empty for the close *after* the one that would cause ixwebsocket to give a 1011
* the ReadyState of the socket from within the user-defined callback will be CLOSING now instead of OPEN

you also mentioned the closing test (IXWebSocketCloseTest) which i was able to run on both mingw64 and msvc and it seems to have run and passed just fine, so maybe i can enable that as part of this pr?