### PR TITLE
Fix error C2065: 'errorMsg': undeclared identifier

### DIFF
--- a/ixwebsocket/IXSocketMbedTLS.cpp
+++ b/ixwebsocket/IXSocketMbedTLS.cpp
@@ -49,7 +49,7 @@ namespace ix
         mbedtls_pk_init(&_pkey);
     }
 
-    bool SocketMbedTLS::loadSystemCertificates(std::string& /* errorMsg */)
+    bool SocketMbedTLS::loadSystemCertificates(std::string& errorMsg)
     {
 #ifdef _WIN32
         DWORD flags = CERT_STORE_READONLY_FLAG | CERT_STORE_OPEN_EXISTING_FLAG |


### PR DESCRIPTION
I am a maintainer of vcpkg, and when I updated `ixwebsocket` to version 11.4.4, I encountered the following errors:
```
\ixwebsocket\IXSocketMbedTLS.cpp(61): error C2065: 'errorMsg': undeclared identifier
\ixwebsocket\IXSocketMbedTLS.cpp(62): error C2065: 'errorMsg': undeclared identifier
\ixwebsocket\IXSocketMbedTLS.cpp(88): error C2065: 'errorMsg': undeclared identifier
```
Above errors occurred because `errorMsg` was commented out in PR https://github.com/machinezone/IXWebSocket/pull/399, I don't know why it was commented out.

To fix this issue, I uncomment the codes.