### PR TITLE
Fix server empty thread name

### DIFF
--- a/ixwebsocket/IXWebSocket.cpp
+++ b/ixwebsocket/IXWebSocket.cpp
@@ -41,6 +41,7 @@ namespace ix
         , _enablePong(kDefaultEnablePong)
         , _pingIntervalSecs(kDefaultPingIntervalSecs)
         , _pingType(SendMessageKind::Ping)
+        , _autoThreadName(true)
     {
         _ws.setOnCloseCallback(
             [this](uint16_t code, const std::string& reason, size_t wireSize, bool remote)
@@ -370,7 +371,10 @@ namespace ix
 
     void WebSocket::run()
     {
-        setThreadName(getUrl());
+        if (_autoThreadName)
+        {
+            setThreadName(getUrl());
+        }
 
         bool firstConnectionAttempt = true;
 
@@ -626,5 +630,10 @@ namespace ix
     {
         std::lock_guard<std::mutex> lock(_configMutex);
         return _subProtocols;
+    }
+
+    void WebSocket::setAutoThreadName(bool enabled)
+    {
+        _autoThreadName = enabled;
     }
 } // namespace ix

--- a/ixwebsocket/IXWebSocket.h
+++ b/ixwebsocket/IXWebSocket.h
@@ -119,6 +119,8 @@ namespace ix
         uint32_t getMinWaitBetweenReconnectionRetries() const;
         const std::vector<std::string>& getSubProtocols();
 
+        void setAutoThreadName(bool enabled);
+
     private:
         WebSocketSendInfo sendMessage(const IXWebSocketSendData& message,
                                       SendMessageKind sendMessageKind,
@@ -181,6 +183,9 @@ namespace ix
 
         // Subprotocols
         std::vector<std::string> _subProtocols;
+
+        // enable or disable auto set thread name
+        bool _autoThreadName;
 
         friend class WebSocketServer;
     };

--- a/ixwebsocket/IXWebSocketServer.cpp
+++ b/ixwebsocket/IXWebSocketServer.cpp
@@ -91,6 +91,9 @@ namespace ix
         setThreadName("Srv:ws:" + connectionState->getId());
 
         auto webSocket = std::make_shared<WebSocket>();
+
+        webSocket->setAutoThreadName(false);
+
         if (_onConnectionCallback)
         {
             _onConnectionCallback(webSocket, connectionState);


### PR DESCRIPTION
setThreadName in WebSocket::run will overwrite the previously set Srv::ws:, and getUrl is empty at this time, resulting in an empty thread name. For the client, 16 characters are not enough to represent very valid information in Linux. So delete setThreadName in WebSocket::run