### PR TITLE
Fix MinGW build warning

### DIFF
--- a/ixwebsocket/IXDNSLookup.cpp
+++ b/ixwebsocket/IXDNSLookup.cpp
@@ -27,8 +27,12 @@
 
 // mingw build quirks
 #if defined(_WIN32) && defined(__GNUC__)
+#ifndef AI_NUMERICSERV
 #define AI_NUMERICSERV NI_NUMERICSERV
+#endif
+#ifndef AI_ADDRCONFIG
 #define AI_ADDRCONFIG LUP_ADDRCONFIG
+#endif
 #endif
 
 namespace ix

--- a/ixwebsocket/IXNetSystem.cpp
+++ b/ixwebsocket/IXNetSystem.cpp
@@ -69,7 +69,7 @@ namespace ix
             {
                 // We must deselect the networkevents from the socket event. Otherwise the
                 // socket will report states that aren't there.
-                if (_fd != nullptr && _fd->fd != -1)
+                if (_fd != nullptr && (int)_fd->fd != -1)
                     WSAEventSelect(_fd->fd, _event, 0);
                 WSACloseEvent(_event);
             }
@@ -171,7 +171,7 @@ namespace ix
             int count = 0;
             // WSAWaitForMultipleEvents returns the index of the first signaled event. And to emulate WSAPoll()
             // all the signaled events must be processed.
-            while (socketIndex < socketEvents.size())
+            while (socketIndex < (int)socketEvents.size())
             {
                 struct pollfd* fd = socketEvents[socketIndex];
 
@@ -345,7 +345,7 @@ namespace ix
                     buf[best] = buf[best + 1] = ':';
                     memmove(buf + best + 2, buf + best + max, i - best - max + 1);
                 }
-                if (strlen(buf) < l)
+                if (strlen(buf) < (size_t)l)
                 {
                     strcpy(s, buf);
                     return s;

--- a/ixwebsocket/IXSocketOpenSSL.cpp
+++ b/ixwebsocket/IXSocketOpenSSL.cpp
@@ -49,7 +49,7 @@ namespace
         X509_STORE* opensslStore = SSL_CTX_get_cert_store(ssl);
 
         int certificateCount = 0;
-        while (certificateIterator = CertEnumCertificatesInStore(systemStore, certificateIterator))
+        while ((certificateIterator = CertEnumCertificatesInStore(systemStore, certificateIterator)))
         {
             X509* x509 = d2i_X509(NULL,
                                   (const unsigned char**) &certificateIterator->pbCertEncoded,


### PR DESCRIPTION
When using the compiler options -Wall and -Werror, warnings caused by type mismatches are treated as errors, leading to compilation failure.