### PR TITLE
Fix #286 - http response headers overwritten with request headers

### DIFF
--- a/ixwebsocket/IXHttpServer.cpp
+++ b/ixwebsocket/IXHttpServer.cpp
@@ -148,6 +148,7 @@ namespace ix
                     content = gzipCompress(content);
                     headers["Content-Encoding"] = "gzip";
                 }
+                headers["Accept-Encoding"] = "gzip";
 #endif
 
                 // Log request
@@ -160,11 +161,6 @@ namespace ix
                 // FIXME: check extensions to set the content type
                 // headers["Content-Type"] = "application/octet-stream";
                 headers["Accept-Ranges"] = "none";
-
-                for (auto&& it : request->headers)
-                {
-                    headers[it.first] = it.second;
-                }
 
                 return std::make_shared<HttpResponse>(
                     200, "OK", HttpErrorCode::Ok, headers, content);

--- a/test/IXHttpServerTest.cpp
+++ b/test/IXHttpServerTest.cpp
@@ -60,6 +60,7 @@ TEST_CASE("http server", "[httpd]")
         REQUIRE(response->errorCode == HttpErrorCode::Ok);
         REQUIRE(response->statusCode == 200);
         REQUIRE(response->headers["Accept-Encoding"] == "gzip");
+        REQUIRE(response->headers["Content-Encoding"] == "gzip");
 
         server.stop();
     }


### PR DESCRIPTION
Not sure why it was copying request headers to the response so I took that out altogether.   Response headers should be determined by the server and not parroted from the client.   For example, Accept-Encoding and Content-Encoding should be set by the server and not the client as it was before.  With removal of the blind copy of request headers, I added explicit setting of Content-Encoding for the gzip ifdef case and added a test to verify it was set.