### PR TITLE
Allow building without rtti

### DIFF
--- a/ixwebsocket/IXWebSocketProxyServer.cpp
+++ b/ixwebsocket/IXWebSocketProxyServer.cpp
@@ -57,7 +57,7 @@ namespace ix
         server.setOnConnectionCallback(
             [remoteUrl, remoteUrlsMapping](std::weak_ptr<ix::WebSocket> webSocket,
                                            std::shared_ptr<ConnectionState> connectionState) {
-                auto state = std::dynamic_pointer_cast<ProxyConnectionState>(connectionState);
+                auto state = std::static_pointer_cast<ProxyConnectionState>(connectionState);
                 auto remoteIp = connectionState->getRemoteIp();
 
                 // Server connection


### PR DESCRIPTION
Since factory returns a ProxyConnectionState, setOnConnectionCallback will be a ProxyConnectionState. The code already makes that assumption, since it does not check of state return value. Using a static_pointer_cast will allow the library to be build with rtti.