### PR TITLE
allow building when cpp exceptions are disabled

### DIFF
--- a/ixwebsocket/IXHttp.cpp
+++ b/ixwebsocket/IXHttp.cpp
@@ -133,6 +133,7 @@ namespace ix
         if (headers.find("Content-Length") != headers.end())
         {
             int contentLength = 0;
+#ifdef __cpp_exceptions
             try
             {
                 contentLength = std::stoi(headers["Content-Length"]);
@@ -142,7 +143,22 @@ namespace ix
                 return std::make_tuple(
                     false, "Error parsing HTTP Header 'Content-Length'", httpRequest);
             }
-
+#else
+            {
+                const char* p = headers["Content-Length"].c_str();
+                char* p_end{};
+                errno = 0;
+                long val = std::strtol(p, &p_end, 10);
+                if (p_end == p            // invalid argument
+                    || errno == ERANGE    // out of range
+                    || val < std::numeric_limits<int>::min()
+                    || val > std::numeric_limits<int>::max()) {
+                    return std::make_tuple(
+                        false, "Error parsing HTTP Header 'Content-Length'", httpRequest);
+                }
+                contentLength = val;
+            }
+#endif
             if (contentLength < 0)
             {
                 return std::make_tuple(


### PR DESCRIPTION
IXWebSocket needs exceptions support because of the use of stoi. In order to build when cpp exceptions are disabled, we can use strtol when __cpp_exceptions is not set