### PR TITLE
Don't call close() on -1.

### DIFF
--- a/ixwebsocket/IXSelectInterruptPipe.cpp
+++ b/ixwebsocket/IXSelectInterruptPipe.cpp
@@ -34,8 +34,12 @@ namespace ix
 
     SelectInterruptPipe::~SelectInterruptPipe()
     {
-        ::close(_fildes[kPipeReadIndex]);
-        ::close(_fildes[kPipeWriteIndex]);
+        if (-1 != _fildes[kPipeReadIndex]) {
+            ::close(_fildes[kPipeReadIndex]);
+        }
+        if (-1 != _fildes[kPipeWriteIndex]) {
+            ::close(_fildes[kPipeWriteIndex]);
+        }
         _fildes[kPipeReadIndex] = -1;
         _fildes[kPipeWriteIndex] = -1;
     }


### PR DESCRIPTION
Valgrind keeps complaining that close() on the invalid descriptor -1 is happening here. I suppose that close shouldn't be called when the descriptor value is known to be invalid. It's not a fatal error or something, but this practice is able to create a lot of flood in the logs.