### PR TITLE
Don't read() from the invalid descriptor

### DIFF
--- a/ixwebsocket/IXSelectInterruptPipe.cpp
+++ b/ixwebsocket/IXSelectInterruptPipe.cpp
@@ -134,6 +134,9 @@ namespace ix
 
         int fd = _fildes[kPipeReadIndex];
 
+        // A weird state has been reached (consider reporting to the error log?)
+        if (-1 == fd) return std::numeric_limits<uint64_t>::max();
+
         uint64_t value = 0;
 
         ssize_t ret = -1;


### PR DESCRIPTION
Having the invalid value of descriptor here might be considered weird, but it happens nevertheless, when you're DoSing the websocket endpoint using the 3G connection. It makes sense to return the generic error here instead of trying to read() from it.