### PR TITLE
Support URLs with no slash before the question mark

### DIFF
--- a/ixwebsocket/IXUrlParser.cpp
+++ b/ixwebsocket/IXUrlParser.cpp
@@ -180,7 +180,7 @@ namespace
                 bHasUserName = true;
                 break;
             }
-            else if (*LocalString == '/')
+            else if (*LocalString == '/' || *LocalString == '?')
             {
                 // end of <host>:<port> specification
                 bHasUserName = false;
@@ -242,7 +242,7 @@ namespace
                 LocalString++;
                 break;
             }
-            else if (!bHasBracket && (*LocalString == ':' || *LocalString == '/'))
+            else if (!bHasBracket && (*LocalString == ':' || *LocalString == '/' || *LocalString == '?'))
             {
                 // port number is specified
                 break;
@@ -280,12 +280,14 @@ namespace
         }
 
         // skip '/'
-        if (*CurrentString != '/')
+        if (*CurrentString != '/' && *CurrentString != '?')
         {
             return clParseURL(LUrlParserError_NoSlash);
         }
 
-        CurrentString++;
+        if (*CurrentString != '?') {
+            CurrentString++;
+        }
 
         // parse the path
         LocalString = CurrentString;

--- a/test/IXUrlParserTest.cpp
+++ b/test/IXUrlParserTest.cpp
@@ -84,6 +84,23 @@ namespace ix
             REQUIRE(port == 443); // default port for wss
         }
 
+        SECTION("wss://google.com/?arg=value")
+        {
+            std::string url = "wss://google.com?arg=value&arg2=value2";
+            std::string protocol, host, path, query;
+            int port;
+            bool res;
+
+            res = UrlParser::parse(url, protocol, host, path, query, port);
+
+            REQUIRE(res);
+            REQUIRE(protocol == "wss");
+            REQUIRE(host == "google.com");
+            REQUIRE(path == "/?arg=value&arg2=value2");
+            REQUIRE(query == "arg=value&arg2=value2");
+            REQUIRE(port == 443); // default port for wss
+        }
+
         SECTION("wss://google.com?arg=value")
         {
             std::string url = "wss://google.com?arg=value&arg2=value2";
@@ -96,7 +113,7 @@ namespace ix
             REQUIRE(res);
             REQUIRE(protocol == "wss");
             REQUIRE(host == "google.com");
-            REQUIRE(path == "?arg=value&arg2=value2");
+            REQUIRE(path == "/?arg=value&arg2=value2");
             REQUIRE(query == "arg=value&arg2=value2");
             REQUIRE(port == 443); // default port for wss
         }

--- a/test/IXUrlParserTest.cpp
+++ b/test/IXUrlParserTest.cpp
@@ -84,6 +84,23 @@ namespace ix
             REQUIRE(port == 443); // default port for wss
         }
 
+        SECTION("wss://google.com?arg=value")
+        {
+            std::string url = "wss://google.com?arg=value&arg2=value2";
+            std::string protocol, host, path, query;
+            int port;
+            bool res;
+
+            res = UrlParser::parse(url, protocol, host, path, query, port);
+
+            REQUIRE(res);
+            REQUIRE(protocol == "wss");
+            REQUIRE(host == "google.com");
+            REQUIRE(path == "?arg=value&arg2=value2");
+            REQUIRE(query == "arg=value&arg2=value2");
+            REQUIRE(port == 443); // default port for wss
+        }
+
         SECTION("real test")
         {
             std::string url =

--- a/test/IXUrlParserTest.cpp
+++ b/test/IXUrlParserTest.cpp
@@ -86,7 +86,7 @@ namespace ix
 
         SECTION("wss://google.com/?arg=value")
         {
-            std::string url = "wss://google.com?arg=value&arg2=value2";
+            std::string url = "wss://google.com/?arg=value&arg2=value2";
             std::string protocol, host, path, query;
             int port;
             bool res;


### PR DESCRIPTION
A URL such wss://google.com?arg=value&arg2=value2 is also valid, this PR adds support for it