### PR TITLE
Fix bad version variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,8 +168,7 @@ if(BUILD_SHARED_LIBS)
     )
 
     # Set library version
-    set_target_properties(ixwebsocket PROPERTIES VERSION ${CMAKE_PROJECT_VERSION})
-
+    set_target_properties(ixwebsocket PROPERTIES VERSION ${PROJECT_VERSION})
 else()
     # Static library
     add_library( ixwebsocket


### PR DESCRIPTION
397bb5d18a6fa5c37cf999339959efa1f58080c3 introduced a bug by using `CMAKE_PROJECT_VERSION`. While a valid variable, to [quote the documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_PROJECT_VERSION.html),

> This variable holds the version of the project as specified **in the top level CMakeLists.txt** file by a [project()](https://cmake.org/cmake/help/latest/command/project.html#command:project) command

This is a problem if using IXWebSocket as a submodule, as IXWebSocket is no longer the top-level project in this scenario. Best-case, the version for the resulting shared library is wrong. Worst-case, which happened to a project of mine, no version is defined, and everything explodes. Because the variable is then interpreted to be empty, a `set_target_properties` call explodes, because it thinks it's missing an argument:

```
CMake Error at build/_deps/ixwebsocket-src/CMakeLists.txt:171 (set_target_properties):
    set_target_properties called with incorrect number of arguments. 
```

The correct variable to use is [`PROJECT_VERSION`](https://cmake.org/cmake/help/latest/variable/PROJECT_VERSION.html), which returns the VERSION option for the last project command, i.e. the one defined by IXWebSocket