### PR TITLE
IXSocket.h: add missing <sys/types.h> for macOS

### DIFF
--- a/ixwebsocket/IXSocket.h
+++ b/ixwebsocket/IXSocket.h
@@ -13,6 +13,10 @@
 #include <mutex>
 #include <string>
 
+#ifdef __APPLE__
+#include <sys/types.h>
+#endif
+
 #ifdef _WIN32
 #include <basetsd.h>
 #ifdef _MSC_VER


### PR DESCRIPTION
Fixes an error with undefined `ssize_t`