### PR TITLE
Initialize the PSA Crypto API if requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ If your company or project is using this library, feel free to open an issue or 
 - [Abaddon](https://github.com/uowuo/abaddon), An alternative Discord client made with C++/gtkmm 
 - [NovaCoin](https://github.com/novacoin-project/novacoin), a hybrid scrypt PoW + PoS based cryptocurrency.
 - [Candy](https://github.com/lanthora/candy), A WebSocket and TUN based VPN for Linux 
+- [ITGmania](https://github.com/itgmania/itgmania), a cross platform Dance Dance Revolution-like emulator.
 
 ## Alternative libraries
 

--- a/ixwebsocket/IXSocketMbedTLS.cpp
+++ b/ixwebsocket/IXSocketMbedTLS.cpp
@@ -47,6 +47,12 @@ namespace ix
         mbedtls_x509_crt_init(&_cacert);
         mbedtls_x509_crt_init(&_cert);
         mbedtls_pk_init(&_pkey);
+        // Initialize the PSA Crypto API if requested.
+        // This allows the X.509/TLS libraries to use PSA for crypto operations.
+        // See: https://github.com/Mbed-TLS/mbedtls/blob/development/docs/use-psa-crypto.md
+        #if defined(IXWEBSOCKET_MBEDTLS_USE_PSA_CRYPTO)
+        psa_crypto_init();
+        #endif
     }
 
     bool SocketMbedTLS::loadSystemCertificates(std::string& errorMsg)


### PR DESCRIPTION
I have an emulator that makes use of IXWebSocket for networking under the hood [here](https://github.com/itgmania/itgmania).

When updating to the latest MbedTLS 3.6.0 LTS, I noticed that our SSL requests started failing, while non-SSL requests were still fine. After some digging, it seems like calling `psa_crypto_init()` somewhere in the code allowed it to start working again, which is what this PR suggests.

In the MbedTLS codebase ([here](https://github.com/Mbed-TLS/mbedtls/blob/development/docs/use-psa-crypto.md)), it says that by using `MBEDTLS_USE_PSA_CRYPTO` we promise to also call `psa_crypto_init()` before calling any PK, X.509 or TLS functions, so we control that using a compile time definition named `IXWEBSOCKET_MBEDTLS_USE_PSA_CRYPTO`.