### PR TITLE
Version check MbedTLS instead of introducing a new define when initializing PSA Crypto API

### DIFF
--- a/ixwebsocket/IXSocketMbedTLS.cpp
+++ b/ixwebsocket/IXSocketMbedTLS.cpp
@@ -47,12 +47,13 @@ namespace ix
         mbedtls_x509_crt_init(&_cacert);
         mbedtls_x509_crt_init(&_cert);
         mbedtls_pk_init(&_pkey);
-        // Initialize the PSA Crypto API if requested.
+        // Initialize the PSA Crypto API if required by the version of Mbed TLS (3.6.0).
         // This allows the X.509/TLS libraries to use PSA for crypto operations.
         // See: https://github.com/Mbed-TLS/mbedtls/blob/development/docs/use-psa-crypto.md
-        #if defined(IXWEBSOCKET_MBEDTLS_USE_PSA_CRYPTO)
-        psa_crypto_init();
-        #endif
+        if (MBEDTLS_VERSION_MAJOR >= 3 && MBEDTLS_VERSION_MINOR >= 6 && MBEDTLS_VERSION_PATCH >= 0)
+        {
+            psa_crypto_init();
+        }
     }
 
     bool SocketMbedTLS::loadSystemCertificates(std::string& errorMsg)


### PR DESCRIPTION
This PR removes the define introduced in https://github.com/machinezone/IXWebSocket/pull/514, in favor of just version checking the MbedTLS (defined [here](https://github.com/Mbed-TLS/mbedtls/blob/0e7aaae1fd9b2bb3801bc7839da063e2abb8253b/include/mbedtls/build_info.h#L27-L29)). I think this implementation is more portable as any projects dependent on this change can get it immediately when updating their MbedTLS library, instead of manually adding in a new define.

--------------------
### Details

It looks like brew updated their mbedtls version 2 months ago as per [this link](https://github.com/Homebrew/homebrew-core/commit/54c3c7c0f6cb42efc5fbd6a95afb62fba133c8c0).

This update happened on March 28th, while the last IXWebSocket update before this changed happened one day earlier on [March 27th](https://github.com/machinezone/IXWebSocket/commit/dc8807ec9d25f602d94f023e40a896de820d2bee).

Since there hadn't been any updates to this repo after March 28th, the GitHub action was not run. And since the failing test uses brew install mbedtls [here](https://github.com/machinezone/IXWebSocket/blob/master/.github/workflows/unittest_mac_tsan_mbedtls.yml#L15), it is now getting version 3.6.0, instead of 3.5.2. I think this implies that even without the changes in https://github.com/machinezone/IXWebSocket/pull/514, the runner would have started to fail on the next PR.

Interestingly, and also unknowingly, the changes in https://github.com/machinezone/IXWebSocket/pull/514 were created to address exactly this issue :) The changes in my project to enable IXWebSocket to use that PR can be found [here](https://github.com/itgmania/itgmania/commit/a9fbfe4df089b132263e7e3ca5b896c93bde21cf).