### PR TITLE
Fix: 'Content-Length' header check implicit cast

### DIFF
--- a/ixwebsocket/IXHttp.cpp
+++ b/ixwebsocket/IXHttp.cpp
@@ -135,17 +135,27 @@ namespace ix
             int contentLength = 0;
             {
                 const char* p = headers["Content-Length"].c_str();
-                char* p_end{};
+                char* p_end {};
                 errno = 0;
                 long val = std::strtol(p, &p_end, 10);
-                if (p_end == p            // invalid argument
-                    || errno == ERANGE    // out of range
-                    || val < std::numeric_limits<int>::min()
-                    || val > std::numeric_limits<int>::max()) {
+                if (p_end == p         // invalid argument
+                    || errno == ERANGE // out of range
+                )
+                {
                     return std::make_tuple(
                         false, "Error parsing HTTP Header 'Content-Length'", httpRequest);
                 }
-                contentLength = val;
+                if (val > std::numeric_limits<int>::max())
+                {
+                    return std::make_tuple(
+                        false, "Error: 'Content-Length' value was above max", httpRequest);
+                }
+                if (val < std::numeric_limits<int>::min())
+                {
+                    return std::make_tuple(
+                        false, "Error: 'Content-Length' value was below min", httpRequest);
+                }
+                contentLength = static_cast<int>(val);
             }
             if (contentLength < 0)
             {


### PR DESCRIPTION
Heyo,
Thank you for the awesome library!

I fixed a mildly annoying compiler warning by making this a static cast instead of an implicit one.

I also rearranged some of the checks to add better error messages to the 'Content-Length' header check overall.

First ever contribution to a public repo, let me know if it checks out!