### PR TITLE
Include cstdint for compatibility with GCC 15

### DIFF
--- a/third_party/msgpack11/msgpack11.hpp
+++ b/third_party/msgpack11/msgpack11.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>


### PR DESCRIPTION
cstdint needs to be included explicitly since GCC 15.
https://gcc.gnu.org/gcc-15/porting_to.html

Downstream bug: https://bugs.gentoo.org/937500

```
$ cmake -B build -DUSE_WS=ON -DCMAKE_DISABLE_PRECOMPILE_HEADERS=OFF
$ cmake --build build
[ 93%] Building CXX object ws/CMakeFiles/ws.dir/__/third_party/msgpack11/msgpack11.cpp.o
In file included from /IXWebSocket/third_party/msgpack11/msgpack11.cpp:1:
/IXWebSocket/third_party/msgpack11/msgpack11.hpp:53:25: error: 'uint8_t' was not declared in this scope
   53 |     typedef std::vector<uint8_t> binary;
      |                         ^~~~~~~
```