### PR TITLE
IXWebSocketTransport::setReadyState(): Run under lock

### DIFF
--- a/ixwebsocket/IXWebSocketTransport.cpp
+++ b/ixwebsocket/IXWebSocketTransport.cpp
@@ -205,6 +205,12 @@ namespace ix
 
     void WebSocketTransport::setReadyState(ReadyState readyState)
     {
+        // Lock the _setReadyStateMutex for the duration of this
+        // method. This ensures that only a single thread runs the
+        // logic below avoiding concurrent execution of the
+        // close callback my multiple threads at the same time.
+        std::lock_guard<std::mutex> lock(_setReadyStateMutex);
+
         // No state change, return
         if (_readyState == readyState) return;
 

--- a/ixwebsocket/IXWebSocketTransport.h
+++ b/ixwebsocket/IXWebSocketTransport.h
@@ -185,6 +185,8 @@ namespace ix
 
         // Hold the state of the connection (OPEN, CLOSED, etc...)
         std::atomic<ReadyState> _readyState;
+        // Mutex to serialize setReadyState() execution.
+        std::mutex _setReadyStateMutex;
 
         OnCloseCallback _onCloseCallback;
         std::string _closeReason;


### PR DESCRIPTION
When setReadyState(CLOSED) is executed from two different threads (the server's thread, detecting a close trying to receive and a separate sending thread), there is a race where both see _readyState as non-CLOSED and both execute the _onCloseCallback().  Worse, the server's thread might be returning from ->run(), unsetting the callback, while the other thread is still about to call the _onCloseCallback(), resulting in a crash rather than "just" a duplicate invocation.

This change ensures that setReadyState() *and* the_onCloseCallback() are executed by a single thread till completion.

I was tempted to remove the std::atomic<> for _readyState, but left it assuming it's still good having for getReadyState().

I've first tried _readyState.exchange() which seemed promising, but still crashed once in a while as racing threads do not wait for the _onCloseCallback() to complete.

Closes #539 