### PR TITLE
Improve documentation and add an ios build script

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -1,11 +1,37 @@
 ## Build
 
+### Building static libraries
+
+A static library can be build using:
+```
+mkdir build #make a build dir so that you can build out of tree
+cd build
+cmake -DUSE_TLS=1 ..
+make -j
+```
+There are also two build scripts in the `tools` folder for creating static libraries for android and iOS/macOS respectively.<br>
+Arguments can be changed in the script files.
+
+Android:
+```
+mkdir build
+cd build
+./../tools/build_android.sh
+make -j
+```
+macOS & iOS:
+```
+mkdir build
+cd build
+./../tools/build_ios.sh
+```
+
 ### CMake
 
 CMakefiles for the library and the examples are available. This library has few dependencies, so it is possible to just add the source files into your project. Otherwise the usual way will suffice.
 
 ```
-mkdir build # make a build dir so that you can build out of tree.
+mkdir build
 cd build
 cmake -DUSE_TLS=1 ..
 make -j

--- a/tools/build_android.sh
+++ b/tools/build_android.sh
@@ -15,7 +15,13 @@
 # -DANDROID_NATIVE_API_LEVEL=23
 # -DANDROID_TOOLCHAIN=clang
 # jvmArgs :
-# 
+#
+# To use a specific version of openSSL, add the arguments:
+# -DOPENSSL_VERSION="[version]"
+# -DOPENSSL_FOUND=1
+# -DOPENSSL_INCLUDE_DIR=[include path]
+# -DOPENSSL_LIBRARIES="[lib path]/libssl.a;[lib path]/libcrypto.a"
+#
 
 CMAKE_TOOLCHAIN_FILE=/tools/android/android-ndk-r20-darwin/build/cmake/android.toolchain.cmake
 ANDROID_HOME=/tools/android/android-sdk-darwin
@@ -33,4 +39,4 @@ ${CMAKE} \
     -G'Unix Makefiles' \
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} \
     -DCMAKE_MAKE_PROGRAM=make \
-    -DUSE_WS=1
+    -DUSE_TLS=1

--- a/tools/build_ios.sh
+++ b/tools/build_ios.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+#
+# This script creates static libraries for macOS and iOS devices
+#
+# To use a specific OpenSSL version add the arguments:
+# -DOPENSSL_VERSION="[version]" \
+# -DOPENSSL_FOUND=1 \
+# -DOPENSSL_INCLUDE_DIR=[include path] \
+# -DOPENSSL_LIBRARIES="[lib path]/libssl.a;[lib path]/libcrypto.a" \
+#
+
+DEPLOYMENT_TARGET_IOS='12.0'
+DEPLOYMENT_TARGET_MAC='14.0'
+CMAKE_DIR=/Applications/CMake.app/Contents/bin
+CMAKE=${CMAKE_DIR}/cmake
+
+${CMAKE} \
+    .. \
+    -GXcode \
+    -DUSE_TLS=1
+
+mkdir -p ios sim mac
+
+xcodebuild -project 'ixwebsocket.xcodeproj' -target "ixwebsocket" -sdk iphoneos ARCHS='arm64' TARGET_BUILD_DIR='$(PWD)/ios' BUILT_PRODUCTS_DIR='$(PWD)/ios' TARGET_NAME='ixwebsocket' IPHONEOS_DEPLOYMENT_TARGET=${DEPLOYMENT_TARGET_IOS}
+xcodebuild -project 'ixwebsocket.xcodeproj' -target "ixwebsocket" -sdk iphonesimulator ARCHS='x86_64' TARGET_BUILD_DIR='$(PWD)/sim' BUILT_PRODUCTS_DIR='$(PWD)/sim' TARGET_NAME='ixwebsocket' IPHONEOS_DEPLOYMENT_TARGET=${DEPLOYMENT_TARGET_IOS}
+xcodebuild -project 'ixwebsocket.xcodeproj' -target "ixwebsocket" -destination 'platform=OS X' ARCHS='x86_64 arm64' TARGET_BUILD_DIR='$(PWD)/mac' BUILT_PRODUCTS_DIR='$(PWD)/mac' TARGET_NAME='ixwebsocket' MACOSX_DEPLOYMENT_TARGET=${DEPLOYMENT_TARGET_MAC}
+
+rm -rf ./out/*.a
+rm -rf ./out/ios/*.a
+rm -rf ./out/mac/*.a
+mkdir -p out
+mkdir -p ./out/ios ./out/mac
+lipo -create "./ios/libixwebsocket.a" "./sim/libixwebsocket.a" -output ./out/ios/libixwebsocket.a
+cp "./mac/libixwebsocket.a" ./out/mac/libixwebsocket.a


### PR DESCRIPTION
Opening this PR to document my findings and close #546. Adding a script for building a static lib for ios, some minor changes to the build_android.sh script to make usage of it clearer and adding to the build documentation.