### PR TITLE
IXWebSocketTransport: Avoid bloating _rxbuf

### DIFF
--- a/ixwebsocket/IXWebSocketTransport.h
+++ b/ixwebsocket/IXWebSocketTransport.h
@@ -158,6 +158,10 @@ namespace ix
         // data messages. That buffer is resized
         std::vector<uint8_t> _rxbuf;
 
+        // If set to a positive value, only read bytes from the socket until
+        // _rxbuf has reached this size to avoid unnecessary erase churn.
+        uint64_t _rxbufWanted = 0;
+
         // Contains all messages that are waiting to be sent
         std::vector<uint8_t> _txbuf;
         mutable std::mutex _txbufMutex;


### PR DESCRIPTION
Buffering too much data into _rxbuf results in dispatch() processing to run into a performance issue due to calling _rxbuf.erase() for each frame.

Concretely, if _rxbuf grows large due to a client sending frames very fast, each processing in dispatch() results in moving the remaining buffer to the front.

Instead of restructuring to avoid .erase(), this patch limits the maximum size of _rxbuf to kChunkSize to alleviate the O^2 erase() overhead. It also has the side-effect of keeping the received data in the OS's TCP stack, building up back pressure to the client earlier if the server code can't keep up.

Fixes #429