### PR TITLE
IXSocketServer: memset() sock addr before bind

### DIFF
--- a/ixwebsocket/IXSocketServer.cpp
+++ b/ixwebsocket/IXSocketServer.cpp
@@ -101,6 +101,7 @@ namespace ix
         if (_addressFamily == AF_INET)
         {
             struct sockaddr_in server;
+            memset(&server, '\0', sizeof(server));
             server.sin_family = _addressFamily;
             server.sin_port = htons(_port);
 
@@ -130,6 +131,7 @@ namespace ix
         else // AF_INET6
         {
             struct sockaddr_in6 server;
+            memset(&server, '\0', sizeof(server));
             server.sin6_family = _addressFamily;
             server.sin6_port = htons(_port);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ set (TEST_TARGET_NAMES
   IXExponentialBackoffTest
   IXWebSocketCloseTest
   IXWebSocketHostTest
+  IXWebSocketIPv6Test
 )
 
 # Some unittest don't work on windows yet

--- a/test/IXWebSocketIPv6Test.cpp
+++ b/test/IXWebSocketIPv6Test.cpp
@@ -1,0 +1,25 @@
+#include "IXTest.h"
+#include "catch.hpp"
+#include <ixwebsocket/IXWebSocket.h>
+#include <ixwebsocket/IXWebSocketServer.h>
+
+using namespace ix;
+
+TEST_CASE("IPv6")
+{
+    SECTION("Listening on ::1 works with AF_INET6 works")
+    {
+        int port = getFreePort();
+        ix::WebSocketServer server(port,
+                                   "::1",
+                                   SocketServer::kDefaultTcpBacklog,
+                                   SocketServer::kDefaultMaxConnections,
+                                   WebSocketServer::kDefaultHandShakeTimeoutSecs,
+                                   AF_INET6);
+
+        auto res = server.listen();
+        CHECK(res.first);
+        server.start();
+        server.stop();
+    }
+}


### PR DESCRIPTION
Listening on IPv6 `::1` on FreeBSD fails due to the `sockadd_in6` struct not being set to zero. Do so and add a smoke test for listening on `::1`. This test passes on Linux as is, but failed on FreeBSD before the `memset()` fix.