### PR TITLE
Fix spelling in comment: 'perpertually' → 'perpetually'

### DIFF
--- a/ixwebsocket/IXWebSocket.cpp
+++ b/ixwebsocket/IXWebSocket.cpp
@@ -310,7 +310,7 @@ namespace ix
         uint32_t retries = 0;
         millis duration(0);
 
-        // Try to connect perpertually
+        // Try to connect perpetually
         while (true)
         {
             if (isConnected() || isClosing() || _stop)


### PR DESCRIPTION
While reading through `WebSocket::checkConnection`, I noticed a small typo in the comment.
This PR corrects "perpertually" to "perpetually" for clarity and correctness.