### PR TITLE
Enable CMAKE_MSVC_RUNTIME_LIBRARY support via CMP0091 policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 
 cmake_minimum_required(VERSION 3.4.1...3.17.2)
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif()
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake;${CMAKE_MODULE_PATH}")
 
 project(ixwebsocket LANGUAGES C CXX VERSION 11.4.6)


### PR DESCRIPTION
## Summary

This PR enables users to configure the MSVC runtime library using `CMAKE_MSVC_RUNTIME_LIBRARY` (e.g., `MultiThreaded` or `MultiThreadedDebug`) for static linking scenarios on Windows.

## Problem

Without the `CMP0091` policy set to `NEW`, the `CMAKE_MSVC_RUNTIME_LIBRARY` CMake variable is ignored. This makes it impossible to build with static runtime (`/MT`, `/MTd`) via CMake parameters alone.

## Solution

Add a conditional policy check that:
- Enables `CMP0091` when available (CMake 3.15+)
- Maintains backward compatibility with older CMake versions

## Example Usage

After this change, users can build with a static runtime:
```bash
cmake -B build -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded