### PR TITLE
Add support for LibreSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,16 +125,16 @@ option(USE_TLS "Enable TLS support" FALSE)
 if (USE_TLS)
     # default to securetranport on Apple if nothing is configured
     if (APPLE)
-      if (NOT USE_MBED_TLS AND NOT USE_OPEN_SSL) # unless we want something else
+      if (NOT USE_MBED_TLS AND NOT USE_OPEN_SSL AND NOT USE_LIBRE_SSL) # unless we want something else
         set(USE_SECURE_TRANSPORT ON)
       endif()
     # default to mbedtls on windows if nothing is configured
     elseif (WIN32)
-      if (NOT USE_OPEN_SSL) # unless we want something else
+      if (NOT USE_OPEN_SSL AND NOT USE_LIBRE_SSL) # unless we want something else
         set(USE_MBED_TLS ON)
       endif()
     else() # default to OpenSSL on all other platforms
-      if (NOT USE_MBED_TLS) # Unless mbedtls is requested
+      if (NOT USE_MBED_TLS AND NOT USE_LIBRE_SSL) # Unless mbedtls or libressl is requested
         set(USE_OPEN_SSL ON)
         set(requires "openssl")
       endif()
@@ -146,7 +146,7 @@ if (USE_TLS)
     elseif (USE_SECURE_TRANSPORT)
         list( APPEND IXWEBSOCKET_HEADERS ixwebsocket/IXSocketAppleSSL.h)
         list( APPEND IXWEBSOCKET_SOURCES ixwebsocket/IXSocketAppleSSL.cpp)
-    elseif (USE_OPEN_SSL)
+    elseif (USE_OPEN_SSL OR USE_LIBRE_SSL)
         list( APPEND IXWEBSOCKET_HEADERS ixwebsocket/IXSocketOpenSSL.h)
         list( APPEND IXWEBSOCKET_SOURCES ixwebsocket/IXSocketOpenSSL.cpp)
     else()
@@ -183,6 +183,8 @@ if (USE_TLS)
         target_compile_definitions(ixwebsocket PUBLIC IXWEBSOCKET_USE_MBED_TLS)
     elseif (USE_OPEN_SSL)
         target_compile_definitions(ixwebsocket PUBLIC IXWEBSOCKET_USE_OPEN_SSL)
+    elseif (USE_LIBRE_SSL)
+        target_compile_definitions(ixwebsocket PUBLIC IXWEBSOCKET_USE_LIBRE_SSL)
     elseif (USE_SECURE_TRANSPORT)
         target_compile_definitions(ixwebsocket PUBLIC IXWEBSOCKET_USE_SECURE_TRANSPORT)
     else()
@@ -227,6 +229,16 @@ if (USE_TLS)
     endif()
     target_include_directories(ixwebsocket PUBLIC $<BUILD_INTERFACE:${MBEDTLS_INCLUDE_DIRS}>)
     target_link_libraries(ixwebsocket PRIVATE ${MBEDTLS_LIBRARIES})
+  elseif (USE_LIBRE_SSL)
+    message(STATUS "TLS configured to use libressl")
+
+    if (NOT LIBRESSL_FOUND)
+      find_package(LibreSSL REQUIRED)
+    endif()
+    message(STATUS "LibreSSL: " ${LIBRESSL_VERSION})
+
+    target_include_directories(ixwebsocket PUBLIC $<BUILD_INTERFACE:${LIBRESSL_INCLUDE_DIR}>)
+    target_link_libraries(ixwebsocket PRIVATE ${LIBRESSL_LIBRARIES})
   elseif (USE_SECURE_TRANSPORT)
     message(STATUS "TLS configured to use secure transport")
     target_link_libraries(ixwebsocket PRIVATE "-framework Foundation" "-framework Security")

--- a/ixwebsocket/IXSocketFactory.cpp
+++ b/ixwebsocket/IXSocketFactory.cpp
@@ -11,7 +11,7 @@
 
 #ifdef IXWEBSOCKET_USE_MBED_TLS
 #include "IXSocketMbedTLS.h"
-#elif defined(IXWEBSOCKET_USE_OPEN_SSL)
+#elif defined(IXWEBSOCKET_USE_OPEN_SSL) || defined(IXWEBSOCKET_USE_LIBRE_SSL)
 #include "IXSocketOpenSSL.h"
 #elif __APPLE__
 #include "IXSocketAppleSSL.h"
@@ -43,7 +43,7 @@ namespace ix
 #ifdef IXWEBSOCKET_USE_TLS
 #if defined(IXWEBSOCKET_USE_MBED_TLS)
             socket = ix::make_unique<SocketMbedTLS>(tlsOptions, fd);
-#elif defined(IXWEBSOCKET_USE_OPEN_SSL)
+#elif defined(IXWEBSOCKET_USE_OPEN_SSL) || defined(IXWEBSOCKET_USE_LIBRE_SSL)
             socket = ix::make_unique<SocketOpenSSL>(tlsOptions, fd);
 #elif defined(__APPLE__)
             socket = ix::make_unique<SocketAppleSSL>(tlsOptions, fd);

--- a/ixwebsocket/IXSocketOpenSSL.cpp
+++ b/ixwebsocket/IXSocketOpenSSL.cpp
@@ -5,7 +5,7 @@
  *
  *  Adapted from Satori SDK OpenSSL code.
  */
-#ifdef IXWEBSOCKET_USE_OPEN_SSL
+#if defined(IXWEBSOCKET_USE_OPEN_SSL) || defined(IXWEBSOCKET_USE_LIBRE_SSL)
 
 #include "IXSocketOpenSSL.h"
 
@@ -860,4 +860,4 @@ namespace ix
 
 } // namespace ix
 
-#endif // IXWEBSOCKET_USE_OPEN_SSL
+#endif // defined(IXWEBSOCKET_USE_OPEN_SSL) || defined(IXWEBSOCKET_USE_LIBRE_SSL)

--- a/ixwebsocket/IXSocketOpenSSL.h
+++ b/ixwebsocket/IXSocketOpenSSL.h
@@ -3,7 +3,7 @@
  *  Author: Benjamin Sergeant, Matt DeBoer
  *  Copyright (c) 2017-2020 Machine Zone, Inc. All rights reserved.
  */
-#ifdef IXWEBSOCKET_USE_OPEN_SSL
+#if defined(IXWEBSOCKET_USE_OPEN_SSL) || defined(IXWEBSOCKET_USE_LIBRE_SSL)
 
 #pragma once
 
@@ -65,4 +65,4 @@ namespace ix
 
 } // namespace ix
 
-#endif // IXWEBSOCKET_USE_OPEN_SSL
+#endif // defined(IXWEBSOCKET_USE_OPEN_SSL) || defined(IXWEBSOCKET_USE_LIBRE_SSL)


### PR DESCRIPTION
The frontends are mostly interchangeable between OpenSSL and LibreSSL.

I thought it would be useful for a project licensed under BSD license to support a cryptography library from its "homeland" :)
As the first line says, LibreSSL is not binary compatible with OpenSSL but provides the same interfaces for applications that use the latter so these could be recompiled with the former.
The diff to looks a bit large to me and I was thinking there should be no intentions to touch preprocessor conditions and implicitly treat LibreSSL as OpenSSL.