### PR TITLE
IPv6 bracketed address not functional when used on client side Linux/macOS

### DIFF
--- a/.github/workflows/unittest_mac_tsan_mbedtls.yml
+++ b/.github/workflows/unittest_mac_tsan_mbedtls.yml
@@ -12,6 +12,6 @@ jobs:
     - uses: actions/checkout@v1
     - uses: seanmiddleditch/gha-setup-ninja@master
     - name: install mbedtls
-      run: brew install mbedtls
+      run: brew install mbedtls@3
     - name: make test
       run: make -f makefile.dev test_tsan_mbedtls

--- a/ixwebsocket/IXSocketServer.cpp
+++ b/ixwebsocket/IXSocketServer.cpp
@@ -308,9 +308,11 @@ namespace ix
             }
 
             // Accept a connection.
-            // FIXME: Is this working for ipv6 ?
-            struct sockaddr_in client; // client address information
-            int clientFd;              // socket connected to client
+            // Use sockaddr_storage to accommodate both AF_INET and AF_INET6 addresses.
+            // sockaddr_in is only 16 bytes; sockaddr_in6 is 28 bytes. On Windows, passing
+            // a too-small buffer to accept() causes WSAEFAULT (error 10014).
+            struct sockaddr_storage client; // client address information (IPv4 or IPv6)
+            int clientFd;                   // socket connected to client
             socklen_t addressLen = sizeof(client);
             memset(&client, 0, sizeof(client));
 
@@ -347,7 +349,8 @@ namespace ix
             if (_addressFamily == AF_INET)
             {
                 char remoteIp4[INET_ADDRSTRLEN];
-                if (ix::inet_ntop(AF_INET, &client.sin_addr, remoteIp4, INET_ADDRSTRLEN) == nullptr)
+                auto* client4 = reinterpret_cast<struct sockaddr_in*>(&client);
+                if (ix::inet_ntop(AF_INET, &client4->sin_addr, remoteIp4, INET_ADDRSTRLEN) == nullptr)
                 {
                     int err = Socket::getErrno();
                     std::stringstream ss;
@@ -360,13 +363,14 @@ namespace ix
                     continue;
                 }
 
-                remotePort = ix::network_to_host_short(client.sin_port);
+                remotePort = ix::network_to_host_short(client4->sin_port);
                 remoteIp = remoteIp4;
             }
             else // AF_INET6
             {
                 char remoteIp6[INET6_ADDRSTRLEN];
-                if (ix::inet_ntop(AF_INET6, &client.sin_addr, remoteIp6, INET6_ADDRSTRLEN) ==
+                auto* client6 = reinterpret_cast<struct sockaddr_in6*>(&client);
+                if (ix::inet_ntop(AF_INET6, &client6->sin6_addr, remoteIp6, INET6_ADDRSTRLEN) ==
                     nullptr)
                 {
                     int err = Socket::getErrno();
@@ -380,7 +384,7 @@ namespace ix
                     continue;
                 }
 
-                remotePort = ix::network_to_host_short(client.sin_port);
+                remotePort = ix::network_to_host_short(client6->sin6_port);
                 remoteIp = remoteIp6;
             }
 

--- a/ixwebsocket/IXUrlParser.cpp
+++ b/ixwebsocket/IXUrlParser.cpp
@@ -251,7 +251,17 @@ namespace
             LocalString++;
         }
 
-        Result.m_Host = std::string(CurrentString, LocalString - CurrentString);
+        // For bracketed IPv6 addresses like [::1], strip the surrounding brackets
+        if (bHasBracket)
+        {
+            // CurrentString points to '[', LocalString points one past ']'
+            // so skip the '[' and exclude the ']'
+            Result.m_Host = std::string(CurrentString + 1, LocalString - CurrentString - 2);
+        }
+        else
+        {
+            Result.m_Host = std::string(CurrentString, LocalString - CurrentString);
+        }
 
         CurrentString = LocalString;
 

--- a/ixwebsocket/IXUrlParser.cpp
+++ b/ixwebsocket/IXUrlParser.cpp
@@ -44,9 +44,18 @@ namespace
         LUrlParserError_NoUrlCharacter = 2,
         LUrlParserError_InvalidSchemeName = 3,
         LUrlParserError_NoDoubleSlash = 4,
-        LUrlParserError_NoAtSign = 5,
-        LUrlParserError_UnexpectedEndOfLine = 6,
-        LUrlParserError_NoSlash = 7,
+        LUrlParserError_NoSlash = 5,
+        LUrlParserError_MissingClosingBracketForIPv6 = 6,
+        LUrlParserError_InvalidCharacterAfterIPv6Host = 7,
+        LUrlParserError_MissingHost = 8,
+        LUrlParserError_InvalidPort = 9,
+        LUrlParserError_UnmatchedClosingBracketInHost = 10,
+        LUrlParserError_InvalidOpeningBracketInHost = 11,
+        LUrlParserError_InvalidPortSeparator = 12,
+        LUrlParserError_MissingPortAfterColon = 13,
+        LUrlParserError_EmptyIPv6Host = 14,
+        LUrlParserError_UnbracketedIPv6Host = 15,
+        LUrlParserError_MultipleAtSignsInAuthority = 16,
     };
 
     class clParseURL
@@ -119,230 +128,252 @@ namespace
         return true;
     }
 
-    // based on RFC 1738 and RFC 3986
+    // Practical URI parser for ws/wss/http/https URLs.
+    //
+    // Standards references:
+    // - RFC 3986: generic URI syntax used for scheme, authority, path, query, fragment.
+    // - RFC 3986 Section 3.2.2: IP-literal host syntax (bracketed IPv6 in authority).
+    // - RFC 6455 Section 3: ws/wss URI schemes (default ports handled in getProtocolPort).
+    //
+    // Note: this is not a full RFC validator; it is a fast parser with targeted syntax checks.
     clParseURL clParseURL::ParseURL(const std::string& URL)
     {
         clParseURL Result;
+        const std::size_t npos = std::string::npos;
+        std::size_t current = 0;
 
-        const char* CurrentString = URL.c_str();
-
-        /*
-         *	<scheme>:<scheme-specific-part>
-         *	<scheme> := [a-z\+\-\.]+
-         *	For resiliency, programs interpreting URLs should treat upper case letters as
-         *equivalent to lower case in scheme names
-         */
-
-        // try to read scheme
+        // Step 1: read scheme (<scheme>:) and normalize to lowercase.
+        std::size_t schemeEnd = URL.find(':', current);
+        if (schemeEnd == npos)
         {
-            const char* LocalString = strchr(CurrentString, ':');
-
-            if (!LocalString)
-            {
-                return clParseURL(LUrlParserError_NoUrlCharacter);
-            }
-
-            // save the scheme name
-            Result.m_Scheme = std::string(CurrentString, LocalString - CurrentString);
-
-            if (!IsSchemeValid(Result.m_Scheme))
-            {
-                return clParseURL(LUrlParserError_InvalidSchemeName);
-            }
-
-            // scheme should be lowercase
-            std::transform(
-                Result.m_Scheme.begin(), Result.m_Scheme.end(), Result.m_Scheme.begin(), ::tolower);
-
-            // skip ':'
-            CurrentString = LocalString + 1;
+            return clParseURL(LUrlParserError_NoUrlCharacter);
         }
 
-        /*
-         *	//<user>:<password>@<host>:<port>/<url-path>
-         *	any ":", "@" and "/" must be normalized
-         */
-
-        // skip "//"
-        if (*CurrentString++ != '/') return clParseURL(LUrlParserError_NoDoubleSlash);
-        if (*CurrentString++ != '/') return clParseURL(LUrlParserError_NoDoubleSlash);
-
-        // check if the user name and password are specified
-        bool bHasUserName = false;
-
-        const char* LocalString = CurrentString;
-
-        while (*LocalString)
+        Result.m_Scheme = URL.substr(current, schemeEnd - current);
+        if (!IsSchemeValid(Result.m_Scheme))
         {
-            if (*LocalString == '@')
-            {
-                // user name and password are specified
-                bHasUserName = true;
-                break;
-            }
-            else if (*LocalString == '/' || *LocalString == '?')
-            {
-                // end of <host>:<port> specification
-                bHasUserName = false;
-                break;
-            }
-
-            LocalString++;
+            return clParseURL(LUrlParserError_InvalidSchemeName);
         }
 
-        // user name and password
-        LocalString = CurrentString;
+        std::transform(Result.m_Scheme.begin(),
+                       Result.m_Scheme.end(),
+                       Result.m_Scheme.begin(),
+                       ::tolower);
 
-        if (bHasUserName)
+        current = schemeEnd + 1;
+
+        // Step 2: require authority prefix "//".
+        if (current + 1 >= URL.size() || URL[current] != '/' || URL[current + 1] != '/')
         {
-            // read user name
-            while (*LocalString && *LocalString != ':' && *LocalString != '@')
-                LocalString++;
+            return clParseURL(LUrlParserError_NoDoubleSlash);
+        }
+        current += 2;
 
-            Result.m_UserName = std::string(CurrentString, LocalString - CurrentString);
-
-            // proceed with the current pointer
-            CurrentString = LocalString;
-
-            if (*CurrentString == ':')
-            {
-                // skip ':'
-                CurrentString++;
-
-                // read password
-                LocalString = CurrentString;
-
-                while (*LocalString && *LocalString != '@')
-                    LocalString++;
-
-                Result.m_Password = std::string(CurrentString, LocalString - CurrentString);
-
-                CurrentString = LocalString;
-            }
-
-            // skip '@'
-            if (*CurrentString != '@')
-            {
-                return clParseURL(LUrlParserError_NoAtSign);
-            }
-
-            CurrentString++;
+        // Step 3: locate the authority boundary (<authority> ends at '/' or '?').
+        std::size_t authorityEnd = URL.find_first_of("/?", current);
+        if (authorityEnd == npos)
+        {
+            authorityEnd = URL.size();
         }
 
-        bool bHasBracket = (*CurrentString == '[');
-
-        // go ahead, read the host name
-        LocalString = CurrentString;
-
-        while (*LocalString)
+        // Step 4: parse optional user info (<user>[:<password>]@).
+        bool hasUserInfo = false;
+        std::size_t atPos = URL.find('@', current);
+        if (atPos != npos && atPos < authorityEnd)
         {
-            if (bHasBracket && *LocalString == ']')
-            {
-                // end of IPv6 address
-                LocalString++;
-                break;
-            }
-            else if (!bHasBracket && (*LocalString == ':' || *LocalString == '/' || *LocalString == '?'))
-            {
-                // port number is specified
-                break;
-            }
-
-            LocalString++;
+            hasUserInfo = true;
         }
 
-        // For bracketed IPv6 addresses like [::1], strip the surrounding brackets
-        if (bHasBracket)
+        if (hasUserInfo)
         {
-            // CurrentString points to '[', LocalString points one past ']'
-            // so skip the '[' and exclude the ']'
-            Result.m_Host = std::string(CurrentString + 1, LocalString - CurrentString - 2);
+            // User info can contain ':' but must contain exactly one '@' separator
+            // within the authority segment.
+            if (URL.find('@', atPos + 1) != npos && URL.find('@', atPos + 1) < authorityEnd)
+            {
+                return clParseURL(LUrlParserError_MultipleAtSignsInAuthority);
+            }
+
+            std::size_t colonPos = URL.find(':', current);
+            if (colonPos != npos && colonPos < atPos)
+            {
+                Result.m_UserName = URL.substr(current, colonPos - current);
+                Result.m_Password = URL.substr(colonPos + 1, atPos - colonPos - 1);
+            }
+            else
+            {
+                Result.m_UserName = URL.substr(current, atPos - current);
+            }
+
+            current = atPos + 1;
+        }
+
+        // Step 5: parse host and optional port from authority tail.
+        authorityEnd = URL.find_first_of("/?", current);
+        if (authorityEnd == npos)
+        {
+            authorityEnd = URL.size();
+        }
+
+        std::string authority = URL.substr(current, authorityEnd - current);
+        std::size_t openingBracketPos = authority.find('[');
+        std::size_t closingBracketPos = authority.find(']');
+
+        // Malformed authority checks (RFC 3986):
+        // - IP-literals must be enclosed in '[' and ']' (Section 3.2.2).
+        // - A closing bracket without an opening bracket is invalid.
+        // - An opening bracket is only valid at the beginning of host when parsing [IPv6].
+        // - Unbracketed multi-colon authorities are either invalid separators or IPv6 literals
+        //   missing required brackets.
+        if (closingBracketPos != npos && openingBracketPos == npos)
+        {
+            return clParseURL(LUrlParserError_UnmatchedClosingBracketInHost);
+        }
+
+        if (openingBracketPos != npos && openingBracketPos != 0)
+        {
+            return clParseURL(LUrlParserError_InvalidOpeningBracketInHost);
+        }
+
+        if (openingBracketPos == npos)
+        {
+            const auto colonCount = std::count(authority.begin(), authority.end(), ':');
+            if (colonCount > 1)
+            {
+                bool looksLikeUnbracketedIPv6 =
+                    authority.find('.') == npos &&
+                    authority.find_first_not_of("0123456789abcdefABCDEF:") == npos;
+
+                if (looksLikeUnbracketedIPv6)
+                {
+                    return clParseURL(LUrlParserError_UnbracketedIPv6Host);
+                }
+
+                return clParseURL(LUrlParserError_InvalidPortSeparator);
+            }
+        }
+
+        if (current < authorityEnd && URL[current] == '[')
+        {
+            // Step 5a: bracketed IPv6 host: [<ipv6>][:<port>]
+            std::size_t closeBracket = URL.find(']', current + 1);
+            if (closeBracket == npos || closeBracket >= authorityEnd)
+            {
+                // Bracketed IPv6 literal started but did not terminate before authority end.
+                return clParseURL(LUrlParserError_MissingClosingBracketForIPv6);
+            }
+
+            Result.m_Host = URL.substr(current + 1, closeBracket - current - 1);
+            if (Result.m_Host.empty())
+            {
+                return clParseURL(LUrlParserError_EmptyIPv6Host);
+            }
+
+            std::size_t afterBracket = closeBracket + 1;
+            if (afterBracket < authorityEnd)
+            {
+                if (URL[afterBracket] != ':')
+                {
+                    // After ] only ':' is allowed before authority terminates.
+                    return clParseURL(LUrlParserError_InvalidCharacterAfterIPv6Host);
+                }
+                Result.m_Port = URL.substr(afterBracket + 1, authorityEnd - afterBracket - 1);
+                if (Result.m_Port.empty())
+                {
+                    // ':' present, but no port digits followed.
+                    return clParseURL(LUrlParserError_MissingPortAfterColon);
+                }
+            }
         }
         else
         {
-            Result.m_Host = std::string(CurrentString, LocalString - CurrentString);
+            // Step 5b: regular host: <host>[:<port>]
+            std::size_t colonPos = URL.find(':', current);
+            if (colonPos != npos && colonPos < authorityEnd)
+            {
+                Result.m_Host = URL.substr(current, colonPos - current);
+                Result.m_Port = URL.substr(colonPos + 1, authorityEnd - colonPos - 1);
+                if (Result.m_Port.empty())
+                {
+                    // ':' present, but no port digits followed.
+                    return clParseURL(LUrlParserError_MissingPortAfterColon);
+                }
+            }
+            else
+            {
+                Result.m_Host = URL.substr(current, authorityEnd - current);
+            }
         }
 
-        CurrentString = LocalString;
-
-        // is port number specified?
-        if (*CurrentString == ':')
+        // Step 5c: validate host/port extracted from authority.
+        if (Result.m_Host.empty())
         {
-            CurrentString++;
-
-            // read port number
-            LocalString = CurrentString;
-
-            while (*LocalString && *LocalString != '/')
-                LocalString++;
-
-            Result.m_Port = std::string(CurrentString, LocalString - CurrentString);
-
-            CurrentString = LocalString;
+            // Host is mandatory in authority form: //host[:port]
+            return clParseURL(LUrlParserError_MissingHost);
         }
 
-        // end of string
-        if (!*CurrentString)
+        if (Result.m_Port.find_first_not_of("0123456789") != std::string::npos)
+        {
+            // Port must be decimal digits only (conversion/range checked later by GetPort).
+            return clParseURL(LUrlParserError_InvalidPort);
+        }
+
+        current = authorityEnd;
+
+        // Step 6: if authority reaches end of string, URL parsing is complete.
+        if (current >= URL.size())
         {
             Result.m_ErrorCode = LUrlParserError_Ok;
-
             return Result;
         }
 
-        // skip '/'
-        if (*CurrentString != '/' && *CurrentString != '?')
+        // Step 7: parse path start (either '/' or query-only '?').
+        if (URL[current] != '/' && URL[current] != '?')
         {
             return clParseURL(LUrlParserError_NoSlash);
         }
 
-        if (*CurrentString != '?') {
-            CurrentString++;
+        if (URL[current] == '/')
+        {
+            ++current;
         }
 
-        // parse the path
-        LocalString = CurrentString;
-
-        while (*LocalString && *LocalString != '#' && *LocalString != '?')
-            LocalString++;
-
-        Result.m_Path = std::string(CurrentString, LocalString - CurrentString);
-
-        CurrentString = LocalString;
-
-        // check for query
-        if (*CurrentString == '?')
+        // Step 8: parse path up to '?' or '#'.
+        std::size_t pathEnd = URL.find_first_of("?#", current);
+        if (pathEnd == npos)
         {
-            // skip '?'
-            CurrentString++;
-
-            // read query
-            LocalString = CurrentString;
-
-            while (*LocalString && *LocalString != '#')
-                LocalString++;
-
-            Result.m_Query = std::string(CurrentString, LocalString - CurrentString);
-
-            CurrentString = LocalString;
+            Result.m_Path = URL.substr(current);
+            Result.m_ErrorCode = LUrlParserError_Ok;
+            return Result;
         }
 
-        // check for fragment
-        if (*CurrentString == '#')
+        Result.m_Path = URL.substr(current, pathEnd - current);
+        current = pathEnd;
+
+        // Step 9: parse optional query after '?', up to '#'.
+        if (current < URL.size() && URL[current] == '?')
         {
-            // skip '#'
-            CurrentString++;
+            ++current;
 
-            // read fragment
-            LocalString = CurrentString;
+            std::size_t queryEnd = URL.find('#', current);
+            if (queryEnd == npos)
+            {
+                Result.m_Query = URL.substr(current);
+                Result.m_ErrorCode = LUrlParserError_Ok;
+                return Result;
+            }
 
-            while (*LocalString)
-                LocalString++;
+            Result.m_Query = URL.substr(current, queryEnd - current);
+            current = queryEnd;
+        }
 
-            Result.m_Fragment = std::string(CurrentString, LocalString - CurrentString);
+        // Step 10: parse optional fragment after '#', to end of URL.
+        if (current < URL.size() && URL[current] == '#')
+        {
+            ++current;
+            Result.m_Fragment = URL.substr(current);
         }
 
         Result.m_ErrorCode = LUrlParserError_Ok;
-
         return Result;
     }
 

--- a/ixwebsocket/IXWebSocketHandshake.cpp
+++ b/ixwebsocket/IXWebSocketHandshake.cpp
@@ -112,11 +112,15 @@ namespace ix
         // See https://stackoverflow.com/questions/18265128/what-is-sec-websocket-key-for
         std::string secWebSocketKey = macaron::Base64::Encode(genRandomString(16));
 
+        // For IPv6 addresses, brackets are required in Host and Origin headers (RFC 7230)
+        bool isIPv6Host = host.find(':') != std::string::npos;
+        std::string bracketedHost = isIPv6Host ? "[" + host + "]" : host;
+
         std::stringstream ss;
         ss << "GET " << path << " HTTP/1.1\r\n";
         if (extraHeaders.find("Host") == extraHeaders.end())
         {
-            ss << "Host: " << host << ":" << port << "\r\n";
+            ss << "Host: " << bracketedHost << ":" << port << "\r\n";
         }
         ss << "Upgrade: websocket\r\n";
         ss << "Connection: Upgrade\r\n";
@@ -132,7 +136,7 @@ namespace ix
         // Set an origin header if missing
         if (extraHeaders.find("Origin") == extraHeaders.end())
         {
-            ss << "Origin: " << protocol << "://" << host << ":" << port << "\r\n";
+            ss << "Origin: " << protocol << "://" << bracketedHost << ":" << port << "\r\n";
         }
 
         for (auto& it : extraHeaders)

--- a/makefile.dev
+++ b/makefile.dev
@@ -129,7 +129,7 @@ test_asan:
 	(cd build ; ctest -V .)
 
 test_tsan_mbedtls:
-	mkdir -p build && (cd build ; cmake -GNinja -DCMAKE_INSTALL_MESSAGE=LAZY -DCMAKE_UNITY_BUILD=ON -DCMAKE_BUILD_TYPE=Debug -DUSE_TLS=1 -DUSE_MBED_TLS=1 -DUSE_TEST=1 .. -DCMAKE_C_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer")
+	mkdir -p build && (cd build ; cmake -GNinja -DCMAKE_INSTALL_MESSAGE=LAZY -DCMAKE_UNITY_BUILD=ON -DCMAKE_BUILD_TYPE=Debug -DUSE_TLS=1 -DUSE_MBED_TLS=1 -DUSE_TEST=1 .. -DCMAKE_C_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" -DCMAKE_PREFIX_PATH="$(shell brew --prefix mbedtls@3 2>/dev/null || echo /opt/homebrew/opt/mbedtls@3)")
 	(cd build ; ninja)
 	(cd build ; ninja test)
 

--- a/test/IXUrlParserTest.cpp
+++ b/test/IXUrlParserTest.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <ixwebsocket/IXUrlParser.h>
 #include <string.h>
+#include <vector>
 
 using namespace ix;
 
@@ -146,6 +147,67 @@ namespace ix
                     "QxZiIsInVzbiI6InN2YmhOdlNJSmEifQ.5L8BUbpTA4XAHlSrdwhIVlrlIpRtjExepim7Yh5eEO4&"
                     "status=true&format=protobuf");
             REQUIRE(port == 7350);
+        }
+
+        SECTION("reject malformed IPv4 authority")
+        {
+            std::vector<std::string> malformedUrls = {
+                "ws://:9001/",             // empty host
+                "ws://127.0.0.1::9001/",   // malformed port separator
+                "ws://127.0.0.1:abc/",     // non-numeric port
+                "ws://127.0.0.1:9001abc/", // non-numeric port suffix
+                "ws://127.0.0.1:/",        // missing digits after ':'
+            };
+
+            for (const auto& url : malformedUrls)
+            {
+                std::string protocol, host, path, query;
+                int port = -1;
+
+                bool res = UrlParser::parse(url, protocol, host, path, query, port);
+                CHECK_FALSE(res);
+            }
+        }
+
+        SECTION("reject malformed bracketed IPv6 authority")
+        {
+            std::vector<std::string> malformedUrls = {
+                "ws://[::1/",        // missing closing bracket
+                "ws://[::1]x",       // invalid token after closing bracket
+                "ws://[]:9001/",     // empty IPv6 host
+                "ws://[::1]:abc/",   // non-numeric port
+                "ws://[::1]:9001x/", // non-numeric port suffix
+                "ws://[::1]:/",      // missing digits after ':'
+                "ws://::1]/",        // unmatched closing bracket in authority
+                "ws://[::1/:9001",   // missing closing bracket before path
+                "ws://::1/",         // unbracketed IPv6 authority
+            };
+
+            for (const auto& url : malformedUrls)
+            {
+                std::string protocol, host, path, query;
+                int port = -1;
+
+                bool res = UrlParser::parse(url, protocol, host, path, query, port);
+                CHECK_FALSE(res);
+            }
+        }
+
+        SECTION("reject malformed userinfo")
+        {
+            std::vector<std::string> malformedUrls = {
+                "ws://user@@127.0.0.1/",     // multiple @ separators in authority
+                "ws://user:pass@@[::1]:9001/" // multiple @ separators in authority
+            };
+
+            for (const auto& url : malformedUrls)
+            {
+                std::string protocol, host, path, query;
+                int port = -1;
+
+                bool res = UrlParser::parse(url, protocol, host, path, query, port);
+                CHECK_FALSE(res);
+            }
         }
     }
 

--- a/test/IXWebSocketIPv6Test.cpp
+++ b/test/IXWebSocketIPv6Test.cpp
@@ -1,5 +1,6 @@
 #include "IXTest.h"
 #include "catch.hpp"
+#include <ixwebsocket/IXUrlParser.h>
 #include <ixwebsocket/IXWebSocket.h>
 #include <ixwebsocket/IXWebSocketServer.h>
 
@@ -7,6 +8,31 @@ using namespace ix;
 
 TEST_CASE("IPv6")
 {
+    SECTION("URL parser strips brackets from IPv6 host and parses port")
+    {
+        std::string protocol, host, path, query;
+        int port = -1;
+
+        bool ok = UrlParser::parse("ws://[::1]:9001/chat", protocol, host, path, query, port);
+        CHECK(ok);
+        CHECK(protocol == "ws");
+        CHECK(host == "::1");
+        CHECK(port == 9001);
+        CHECK(path == "/chat");
+    }
+
+    SECTION("URL parser handles IPv6 without port")
+    {
+        std::string protocol, host, path, query;
+        int port = -1;
+
+        bool ok = UrlParser::parse("ws://[::1]/", protocol, host, path, query, port);
+        CHECK(ok);
+        CHECK(protocol == "ws");
+        CHECK(host == "::1");
+        CHECK(port == 80);
+    }
+
     SECTION("Listening on ::1 works with AF_INET6 works")
     {
         int port = getFreePort();

--- a/test/IXWebSocketIPv6Test.cpp
+++ b/test/IXWebSocketIPv6Test.cpp
@@ -48,4 +48,49 @@ TEST_CASE("IPv6")
         server.start();
         server.stop();
     }
+
+    SECTION("Client connects to server via [::1]:port notation")
+    {
+        int port = getFreePort();
+        ix::WebSocketServer server(port,
+                                   "::1",
+                                   SocketServer::kDefaultTcpBacklog,
+                                   SocketServer::kDefaultMaxConnections,
+                                   WebSocketServer::kDefaultHandShakeTimeoutSecs,
+                                   AF_INET6);
+
+        server.setOnClientMessageCallback(
+            [](std::shared_ptr<ix::ConnectionState> /*connectionState*/,
+               ix::WebSocket& /*webSocket*/,
+               const ix::WebSocketMessagePtr& /*msg*/) {});
+
+        auto res = server.listen();
+        REQUIRE(res.first);
+        server.start();
+
+        // Connect using bracketed IPv6 URL notation
+        std::string url = "ws://[::1]:" + std::to_string(port) + "/";
+        ix::WebSocket client;
+        client.setUrl(url);
+
+        std::atomic<bool> connected{false};
+        client.setOnMessageCallback([&connected](const ix::WebSocketMessagePtr& msg) {
+            if (msg->type == ix::WebSocketMessageType::Open)
+            {
+                connected = true;
+            }
+        });
+
+        client.start();
+        int retries = 0;
+        while (!connected && retries < 20)
+        {
+            ix::msleep(100);
+            retries++;
+        }
+        client.stop();
+        server.stop();
+
+        CHECK(connected);
+    }
 }


### PR DESCRIPTION
Hello! In a project at work we are running into trouble using IXWebSocket with bracketed IPv6 addresses, specifically [::1]:1234, and specifically on Linux. Windows worked fine, somehow.

This pull request fixes 2 issues:
1. Bracketed IPv6 addresses not being properly parsed by clParseURL::ParseURL (commit 1)
2. Even after proper parsing, client was not able to connect to server on Linux/macOS because of RFC 7230 violation (brackets are required in Host and Origin headers) (commit 2)

These issues have been manually debugged and fixed at first. I wasn't a fan of the `clParseURL::ParseURL` readability, and my manual fix for the second issue became a bit too complex for comfort in a codebase I'm not familiar with.

As such, I wanted to see how Copilot would handle this + refactoring the `clParseURL::ParseURL` logic and error handling.

This isn't AI slop. All the changes were human reviewed every step of the way and edge case handling was insisted on (I did find some that Copilot didn't handle). Also, tests were introduced for all the modified behavior.

All tests are passing on macOS. They have been also run with fixes disabled, and expectedly failed.

TL;DR: the code and tests are Copilot written but have been human prompted and reviewed. Initial investigation and fix was done 100% manually.
TODO: check the implementation on Linux and Windows (checked only macOS for now), and in our specific project (will come back on Monday with results)

Great project, by the way. This library is a breeze to use compared to Boost.Beast. Your work is much appreciated!