### PR TITLE
Fix SelectInterruptPipe::read() being called with fd -1

### DIFF
--- a/.github/workflows/unittest_mac_tsan_mbedtls.yml
+++ b/.github/workflows/unittest_mac_tsan_mbedtls.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: seanmiddleditch/gha-setup-ninja@master
-    - name: install mbedtls
+    - name: install mbedtls@3
       run: brew install mbedtls@3
     - name: make test
       run: make -f makefile.dev test_tsan_mbedtls

--- a/ixwebsocket/IXSelectInterruptPipe.cpp
+++ b/ixwebsocket/IXSelectInterruptPipe.cpp
@@ -131,7 +131,6 @@ namespace ix
         return ret == 8;
     }
 
-    // TODO: return max uint64_t for errors ?
     uint64_t SelectInterruptPipe::read()
     {
         std::lock_guard<std::mutex> lock(_fildesMutex);
@@ -140,11 +139,11 @@ namespace ix
 
         uint64_t value = 0;
 
-        ssize_t ret = -1;
+        ssize_t readret = -1;
         do
         {
-            ret = ::read(fd, &value, sizeof(value));
-        } while (ret == -1 && errno == EINTR);
+            readret = ::read(fd, &value, sizeof(value));
+        } while (readret == -1 && errno == EINTR);
 
         return value;
     }

--- a/ixwebsocket/IXSocketConnect.cpp
+++ b/ixwebsocket/IXSocketConnect.cpp
@@ -20,7 +20,6 @@
 #include <linux/in.h>
 #include <linux/tcp.h>
 #endif
-#include <ixwebsocket/IXSelectInterruptFactory.h>
 
 namespace ix
 {
@@ -67,8 +66,7 @@ namespace ix
 
             int timeoutMs = 10;
             bool readyToRead = false;
-            SelectInterruptPtr selectInterrupt = ix::createSelectInterrupt();
-            PollResultType pollResult = Socket::poll(readyToRead, timeoutMs, fd, selectInterrupt);
+            PollResultType pollResult = Socket::poll(readyToRead, timeoutMs, fd, nullptr);
 
             if (pollResult == PollResultType::Timeout)
             {

--- a/makefile.dev
+++ b/makefile.dev
@@ -13,6 +13,11 @@ all: brew
 
 install: brew
 
+MBEDTLS_CMAKE_PREFIX :=
+ifeq ($(shell uname),Darwin)
+MBEDTLS_CMAKE_PREFIX := -DCMAKE_PREFIX_PATH=$$(brew --prefix mbedtls@3)
+endif
+
 -DCMAKE_INSTALL_PREFIX=/opt/homebrew
 
 # Use -DCMAKE_INSTALL_PREFIX= to install into another location
@@ -36,7 +41,7 @@ endif
 # server side ?) and I can't work-around it easily, so we're using mbedtls on
 # Linux for the SSL backend, which works great.
 ws_mbedtls_install:
-	mkdir -p build && (cd build ; cmake -GNinja -DCMAKE_UNITY_BUILD=ON -DCMAKE_INSTALL_MESSAGE=LAZY -DCMAKE_BUILD_TYPE=MinSizeRel -DUSE_ZLIB=OFF -DUSE_TLS=1 -DUSE_WS=1 -DUSE_MBED_TLS=1 .. ; ninja install)
+	mkdir -p build && (cd build ; cmake -GNinja -DCMAKE_UNITY_BUILD=ON -DCMAKE_INSTALL_MESSAGE=LAZY -DCMAKE_BUILD_TYPE=MinSizeRel -DUSE_ZLIB=OFF -DUSE_TLS=1 -DUSE_WS=1 -DUSE_MBED_TLS=1 $(MBEDTLS_CMAKE_PREFIX) .. ; ninja install)
 
 ws:
 	mkdir -p build && (cd build ; cmake -GNinja -DCMAKE_INSTALL_MESSAGE=LAZY -DCMAKE_BUILD_TYPE=Debug -DUSE_TLS=1 -DUSE_WS=1 .. && ninja)
@@ -54,7 +59,7 @@ ws_openssl_install:
 	mkdir -p build && (cd build ; cmake -GNinja -DCMAKE_INSTALL_MESSAGE=LAZY -DCMAKE_BUILD_TYPE=Debug -DUSE_TLS=1 -DUSE_WS=1 -DUSE_OPEN_SSL=1 .. ; ninja install)
 
 ws_mbedtls:
-	mkdir -p build && (cd build ; cmake -DCMAKE_INSTALL_MESSAGE=LAZY -DCMAKE_BUILD_TYPE=Debug -DUSE_TLS=1 -DUSE_WS=1 -DUSE_MBED_TLS=1 .. ; ninja)
+	mkdir -p build && (cd build ; cmake -DCMAKE_INSTALL_MESSAGE=LAZY -DCMAKE_BUILD_TYPE=Debug -DUSE_TLS=1 -DUSE_WS=1 -DUSE_MBED_TLS=1 $(MBEDTLS_CMAKE_PREFIX) .. ; ninja)
 
 ws_no_ssl:
 	mkdir -p build && (cd build ; cmake -DCMAKE_INSTALL_MESSAGE=LAZY -DCMAKE_BUILD_TYPE=Debug -DUSE_WS=1 .. ; ninja)
@@ -129,7 +134,7 @@ test_asan:
 	(cd build ; ctest -V .)
 
 test_tsan_mbedtls:
-	mkdir -p build && (cd build ; cmake -GNinja -DCMAKE_INSTALL_MESSAGE=LAZY -DCMAKE_UNITY_BUILD=ON -DCMAKE_BUILD_TYPE=Debug -DUSE_TLS=1 -DUSE_MBED_TLS=1 -DUSE_TEST=1 .. -DCMAKE_C_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" -DCMAKE_PREFIX_PATH="$(shell brew --prefix mbedtls@3 2>/dev/null || echo /opt/homebrew/opt/mbedtls@3)")
+	mkdir -p build && (cd build ; cmake -GNinja -DCMAKE_INSTALL_MESSAGE=LAZY -DCMAKE_UNITY_BUILD=ON -DCMAKE_BUILD_TYPE=Debug -DUSE_TLS=1 -DUSE_MBED_TLS=1 -DUSE_TEST=1 $(MBEDTLS_CMAKE_PREFIX) .. -DCMAKE_C_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer")
 	(cd build ; ninja)
 	(cd build ; ninja test)
 


### PR DESCRIPTION
When using IXWebSocket in our enterprise project, we are getting the following valgrind warning.
Pull request #503 is handling this issue by adding a check to the read location.
This pull requests fixes the root cause, where a `SelectInterruptPtr` is used without being initialized. This `SelectInterruptPtr` is not needed at all at this moment in the code path, so it has been completely replaced with a `nullptr`.

Build and tests are passing, and also our enterprise project is not showing the valgrind warning anymore.

Also, to answer https://github.com/machinezone/IXWebSocket/pull/503#issuecomment-2117064887, the correct error return value at this place is 0, as the parent class `SelectInterrupt` also returns 0 (signaling an error).
https://github.com/machinezone/IXWebSocket/blob/master/ixwebsocket/IXSelectInterrupt.cpp#L36

```
==7952== Warning: invalid file descriptor -1 in syscall read()
==7952==    at 0x4D17ACA: __libc_read (read.c:26)
==7952==    by 0x4D17ACA: read (read.c:24)
==7952==    by 0x16DFCCE: ix::SelectInterruptPipe::read() (IXSelectInterruptPipe.cpp:146)
==7952==    by 0x16DE646: readSelectInterruptRequest (IXSocket.cpp:161)
==7952==    by 0x16DE646: ix::Socket::poll(bool, int, int, std::unique_ptr<ix::SelectInterrupt, std::default_delete<ix::SelectInterrupt> > const&) (IXSocket.cpp:89)
==7952==    by 0x16DFF0E: ix::SocketConnect::connectToAddress(addrinfo const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::function<bool ()> const&) (IXSocketConnect.cpp:71)
==7952==    by 0x16E030D: ix::SocketConnect::connect(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::function<bool ()> const&) (IXSocketConnect.cpp:120)
==7952==    by 0x16DE946: ix::Socket::connect(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::function<bool ()> const&) (IXSocket.cpp:229)
==7952==    by 0x16E2277: ix::WebSocketHandshake::clientHandshake(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ix::CaseInsensitiveLess, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, int) (IXWebSocketHandshake.cpp:102)
==7952==    by 0x16D7559: ix::WebSocketTransport::connectToUrl(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ix::CaseInsensitiveLess, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&, int) (IXWebSocketTransport.cpp:142)
==7952==    by 0x16D216F: ix::WebSocket::connect(int) (IXWebSocket.cpp:233)
==7952==    by 0x16D2B02: ix::WebSocket::checkConnection(bool) (IXWebSocket.cpp:342)
==7952==    by 0x16D1C6F: ix::WebSocket::run() (IXWebSocket.cpp:384)
==7952==    by 0x4A3ADB3: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33)
```