### PR TITLE
Fix HTTP header value parsing: bounds check and robust trimming

### DIFF
--- a/ixwebsocket/IXWebSocketHttpHeaders.cpp
+++ b/ixwebsocket/IXWebSocketHttpHeaders.cpp
@@ -8,7 +8,6 @@
 
 #include "IXSocket.h"
 #include <algorithm>
-#include <locale>
 
 namespace ix
 {
@@ -47,23 +46,25 @@ namespace ix
             {
                 line[i] = '\0';
                 std::string lineStr(line);
-                // colon is ':', usually colon+1 is ' ', and colon+2 is the start of the value.
-                // some webservers do not put a space after the colon character, so
-                // the start of the value might be farther than colon+2.
-                // The spec says that space after the : should be discarded.
-                // i is end of string (\0), i-colon is length of string minus key;
-                // subtract 1 for '\0', 1 for '\n', 1 for '\r',
-                // 1 for the ' ' after the ':', and total is -4
-                // since we use an std::string later on and don't account for '\0',
-                // plus the optional first space, total is -2
+
                 int start = colon + 1;
-                while (lineStr[start] == ' ')
+                while (start < (int) lineStr.size() && lineStr[start] == ' ')
                 {
                     start++;
                 }
 
                 std::string name(lineStr.substr(0, colon));
-                std::string value(lineStr.substr(start, lineStr.size() - start - 2));
+                std::string value;
+                if (start < (int) lineStr.size())
+                {
+                    value = lineStr.substr(start);
+                    // trim trailing whitespace (\r, \n, spaces)
+                    value.erase(std::find_if(value.rbegin(),
+                                             value.rend(),
+                                             [](unsigned char c) { return !std::isspace(c); })
+                                    .base(),
+                                value.end());
+                }
 
                 headers[name] = value;
             }


### PR DESCRIPTION
## Summary

- Add bounds check to the space-skipping `while` loop to prevent UB when the colon is near the end of the line
- Replace the unsigned arithmetic (`lineStr.size() - start - 2`) with a trailing trim on the extracted value — avoids `size_t` underflow and correctly handles both `\r\n` and `\n`-only line endings
- Fix `isspace` UB by casting to `unsigned char` in the lambda
- Remove unused `<locale>` include

This is an alternative to #564 which identified the same root cause but introduced a redundant 1024-byte cap and used `int` in the `isspace` lambda (UB for negative `char` values).

## Test plan
- [ ] Existing test suite passes
- [ ] Headers with empty values parse correctly
- [ ] Headers with no trailing `\r` (Unix line endings) parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)