### PR TITLE
Add timeout support to flushSendBuffer()

### DIFF
--- a/ixwebsocket/IXWebSocket.cpp
+++ b/ixwebsocket/IXWebSocket.cpp
@@ -256,7 +256,8 @@ namespace ix
     WebSocketInitResult WebSocket::connectToSocket(std::unique_ptr<Socket> socket,
                                                    int timeoutSecs,
                                                    bool enablePerMessageDeflate,
-                                                   HttpRequestPtr request)
+                                                   HttpRequestPtr request,
+                                                   int sendTimeoutSecs)
     {
         {
             std::lock_guard<std::mutex> lock(_configMutex);
@@ -264,8 +265,8 @@ namespace ix
                 _perMessageDeflateOptions, _socketTLSOptions, _enablePong, _pingIntervalSecs);
         }
 
-        WebSocketInitResult status =
-            _ws.connectToSocket(std::move(socket), timeoutSecs, enablePerMessageDeflate, request);
+        WebSocketInitResult status = _ws.connectToSocket(
+            std::move(socket), timeoutSecs, enablePerMessageDeflate, request, sendTimeoutSecs);
         if (!status.success)
         {
             return status;

--- a/ixwebsocket/IXWebSocket.h
+++ b/ixwebsocket/IXWebSocket.h
@@ -135,7 +135,8 @@ namespace ix
         WebSocketInitResult connectToSocket(std::unique_ptr<Socket>,
                                             int timeoutSecs,
                                             bool enablePerMessageDeflate,
-                                            HttpRequestPtr request = nullptr);
+                                            HttpRequestPtr request = nullptr,
+                                            int sendTimeoutSecs = -1);
 
         WebSocketTransport _ws;
 

--- a/ixwebsocket/IXWebSocketCloseConstants.cpp
+++ b/ixwebsocket/IXWebSocketCloseConstants.cpp
@@ -19,6 +19,7 @@ namespace ix
     const std::string WebSocketCloseConstants::kInternalErrorMessage("Internal error");
     const std::string WebSocketCloseConstants::kAbnormalCloseMessage("Abnormal closure");
     const std::string WebSocketCloseConstants::kPingTimeoutMessage("Ping timeout");
+    const std::string WebSocketCloseConstants::kSendTimeoutMessage("Send timeout");
     const std::string WebSocketCloseConstants::kProtocolErrorMessage("Protocol error");
     const std::string WebSocketCloseConstants::kNoStatusCodeErrorMessage("No status code");
     const std::string WebSocketCloseConstants::kProtocolErrorReservedBitUsed("Reserved bit used");

--- a/ixwebsocket/IXWebSocketCloseConstants.h
+++ b/ixwebsocket/IXWebSocketCloseConstants.h
@@ -24,6 +24,7 @@ namespace ix
         static const std::string kInternalErrorMessage;
         static const std::string kAbnormalCloseMessage;
         static const std::string kPingTimeoutMessage;
+        static const std::string kSendTimeoutMessage;
         static const std::string kProtocolErrorMessage;
         static const std::string kNoStatusCodeErrorMessage;
         static const std::string kProtocolErrorReservedBitUsed;

--- a/ixwebsocket/IXWebSocketServer.cpp
+++ b/ixwebsocket/IXWebSocketServer.cpp
@@ -20,6 +20,7 @@ namespace ix
     const int WebSocketServer::kDefaultHandShakeTimeoutSecs(3); // 3 seconds
     const bool WebSocketServer::kDefaultEnablePong(true);
     const int WebSocketServer::kPingIntervalSeconds(-1); // disable heartbeat
+    const int WebSocketServer::kSendTimeoutSeconds(-1);
 
     WebSocketServer::WebSocketServer(int port,
                                      const std::string& host,
@@ -27,12 +28,14 @@ namespace ix
                                      size_t maxConnections,
                                      int handshakeTimeoutSecs,
                                      int addressFamily,
-                                     int pingIntervalSeconds)
+                                     int pingIntervalSeconds,
+                                     int sendTimeoutSeconds)
         : SocketServer(port, host, backlog, maxConnections, addressFamily)
         , _handshakeTimeoutSecs(handshakeTimeoutSecs)
         , _enablePong(kDefaultEnablePong)
         , _enablePerMessageDeflate(true)
         , _pingIntervalSeconds(pingIntervalSeconds)
+        , _sendTimeoutSeconds(sendTimeoutSeconds)
     {
     }
 
@@ -144,8 +147,11 @@ namespace ix
             _clients.insert(webSocket);
         }
 
-        auto status = webSocket->connectToSocket(
-            std::move(socket), _handshakeTimeoutSecs, _enablePerMessageDeflate, request);
+        auto status = webSocket->connectToSocket(std::move(socket),
+                                                 _handshakeTimeoutSecs,
+                                                 _enablePerMessageDeflate,
+                                                 request,
+                                                 _sendTimeoutSeconds);
         if (status.success)
         {
             // Process incoming messages and execute callbacks

--- a/ixwebsocket/IXWebSocketServer.h
+++ b/ixwebsocket/IXWebSocketServer.h
@@ -34,7 +34,8 @@ namespace ix
                         size_t maxConnections = SocketServer::kDefaultMaxConnections,
                         int handshakeTimeoutSecs = WebSocketServer::kDefaultHandShakeTimeoutSecs,
                         int addressFamily = SocketServer::kDefaultAddressFamily,
-                        int pingIntervalSeconds = WebSocketServer::kPingIntervalSeconds);
+                        int pingIntervalSeconds = WebSocketServer::kPingIntervalSeconds,
+                        int sendTimeoutSeconds = WebSocketServer::kSendTimeoutSeconds);
         virtual ~WebSocketServer();
         virtual void stop() final;
 
@@ -63,6 +64,7 @@ namespace ix
         bool _enablePong;
         bool _enablePerMessageDeflate;
         int _pingIntervalSeconds;
+        int _sendTimeoutSeconds;
 
         OnConnectionCallback _onConnectionCallback;
         OnClientMessageCallback _onClientMessageCallback;
@@ -72,6 +74,7 @@ namespace ix
 
         const static bool kDefaultEnablePong;
         const static int kPingIntervalSeconds;
+        const static int kSendTimeoutSeconds;
 
         // Methods
         virtual void handleConnection(std::unique_ptr<Socket> socket,

--- a/ixwebsocket/IXWebSocketTransport.cpp
+++ b/ixwebsocket/IXWebSocketTransport.cpp
@@ -61,6 +61,7 @@ namespace ix
     WebSocketTransport::WebSocketTransport()
         : _useMask(true)
         , _blockingSend(false)
+        , _sendTimeoutSecs(-1)
         , _receivedMessageCompressed(false)
         , _readyState(ReadyState::CLOSED)
         , _closeCode(WebSocketCloseConstants::kInternalErrorCode)
@@ -172,13 +173,15 @@ namespace ix
     WebSocketInitResult WebSocketTransport::connectToSocket(std::unique_ptr<Socket> socket,
                                                             int timeoutSecs,
                                                             bool enablePerMessageDeflate,
-                                                            HttpRequestPtr request)
+                                                            HttpRequestPtr request,
+                                                            int sendTimeoutSecs)
     {
         std::lock_guard<std::mutex> lock(_socketMutex);
 
         // Server should not mask the data it sends to the client
         _useMask = false;
         _blockingSend = true;
+        _sendTimeoutSecs = sendTimeoutSecs;
 
         _socket = std::move(socket);
         _perMessageDeflate = ix::make_unique<WebSocketPerMessageDeflate>();
@@ -1242,6 +1245,23 @@ namespace ix
 
     bool WebSocketTransport::flushSendBuffer()
     {
+        auto start = std::chrono::steady_clock::now();
+
+        // timeoutMs tracks how long to wait before forcefully
+        // closing the socket when sending runs into a timeout.
+        std::chrono::seconds timeoutSecs(0);
+        if (_sendTimeoutSecs > 0)
+        {
+            timeoutSecs = std::chrono::seconds(_sendTimeoutSecs);
+        }
+        else if (_pingIntervalSecs > 0)
+        {
+            // If a pingInterval is set, use it as a timeout because if we cannot
+            // send out any data for pingInterval seconds, we may as well disconnet
+            // the client.
+            timeoutSecs = std::chrono::seconds(_pingIntervalSecs);
+        }
+
         while (!isSendBufferEmpty() && !_requestInitCancellation)
         {
             // Wait with a 10ms timeout until the socket is ready to write.
@@ -1258,6 +1278,20 @@ namespace ix
             {
                 if (!sendOnSocket())
                 {
+                    return false;
+                }
+            }
+            else if (result == PollResultType::Timeout && timeoutSecs.count() > 0)
+            {
+                auto now = std::chrono::steady_clock::now();
+                // Timeout error and exceeded the allocated timeout: Treat
+                // as abnormal close and use "Send Timeout" for the reason.
+                if (now > start + timeoutSecs)
+                {
+                    closeSocketAndSwitchToClosedState(WebSocketCloseConstants::kAbnormalCloseCode,
+                                                      WebSocketCloseConstants::kSendTimeoutMessage,
+                                                      0,
+                                                      false);
                     return false;
                 }
             }

--- a/ixwebsocket/IXWebSocketTransport.h
+++ b/ixwebsocket/IXWebSocketTransport.h
@@ -88,7 +88,8 @@ namespace ix
         WebSocketInitResult connectToSocket(std::unique_ptr<Socket> socket,
                                             int timeoutSecs,
                                             bool enablePerMessageDeflate,
-                                            HttpRequestPtr request = nullptr);
+                                            HttpRequestPtr request = nullptr,
+                                            int sendTimeoutSecs = -1);
 
         PollResult poll();
         WebSocketSendInfo sendBinary(const IXWebSocketSendData& message,
@@ -149,6 +150,12 @@ namespace ix
         // Tells whether we should flush the send buffer before
         // saying that a send is complete. This is the mode for server code.
         std::atomic<bool> _blockingSend;
+
+        // A configurable timeout for how long flushSendBuffer() may block
+        // before forcefully closing the client socket with a "Send timeout"
+        // message. This is useful when a client doesn't read from its socket
+        // and the server stalls on trying to send more data.
+        int _sendTimeoutSecs = -1;
 
         // Buffer for reading from our socket. That buffer is never resized.
         std::vector<uint8_t> _readbuf;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,7 @@ set (TEST_TARGET_NAMES
   IXWebSocketCloseTest
   IXWebSocketHostTest
   IXWebSocketIPv6Test
+  IXWebSocketSendTimeoutTest
 )
 
 # Some unittest don't work on windows yet

--- a/test/IXWebSocketSendTimeoutTest.cpp
+++ b/test/IXWebSocketSendTimeoutTest.cpp
@@ -1,0 +1,105 @@
+#include "IXTest.h"
+#include "catch.hpp"
+#include "ixwebsocket/IXWebSocketMessageType.h"
+#include <ixwebsocket/IXUrlParser.h>
+#include <ixwebsocket/IXWebSocket.h>
+#include <ixwebsocket/IXWebSocketServer.h>
+#include <memory>
+
+using namespace ix;
+
+static std::atomic<bool> client_connected {false};
+static std::atomic<bool> client_closed {false};
+
+TEST_CASE("SendTimeout")
+{
+    SECTION("Test send timeout kicking in")
+    {
+        // Create a server with a one second send timeout
+        int port = getFreePort();
+        std::unique_ptr<ix::WebSocketServer> server = std::unique_ptr<ix::WebSocketServer>(
+            new ix::WebSocketServer(port,
+                                    "127.0.0.1",
+                                    SocketServer::kDefaultTcpBacklog,
+                                    SocketServer::kDefaultMaxConnections,
+                                    WebSocketServer::kDefaultHandShakeTimeoutSecs,
+                                    AF_INET,
+                                    /*pingIntervalSeconds=*/5,
+                                    /*sendTimeoutSeconds=*/1));
+
+        auto res = server->listen();
+        REQUIRE(res.first);
+
+        server->setOnConnectionCallback(
+            [](std::weak_ptr<WebSocket> wws, std::shared_ptr<ConnectionState> cs) -> void
+            {
+                TLogger() << "Client connected!";
+                auto ws = wws.lock();
+                client_connected = true;
+
+                // When the client sends a message, send it 50k messages back
+                // to quickly fill up the socket buffer and run into a send
+                // timeout.
+                ws->setOnMessageCallback(
+                    [ws](const WebSocketMessagePtr& wsmptr)
+                    {
+                        if (wsmptr->type == WebSocketMessageType::Message)
+                        {
+                            auto i = 0;
+                            while (++i < 50000)
+                            {
+                                auto r = ws->sendText("SPAM SPAM SPAM SPAM SPAM SPAM!");
+                                if (!r.success)
+                                {
+                                    ws->close();
+                                    break;
+                                }
+                            }
+                        }
+                        else if (wsmptr->type == WebSocketMessageType::Close)
+                        {
+                            TLogger()
+                                << "SERVER: Client connection closed:" << wsmptr->closeInfo.reason;
+                            client_closed = true;
+                        }
+                    });
+            });
+
+        std::string url = "ws://127.0.0.1:" + std::to_string(port) + "/";
+        ix::WebSocket client;
+        client.setUrl(url);
+
+        client.setOnMessageCallback(
+            [&client](const ix::WebSocketMessagePtr& msg)
+            {
+                if (msg->type == ix::WebSocketMessageType::Open)
+                {
+                    TLogger() << "CLIENT: Open";
+                    client.sendText("Hello");
+                }
+                else if (msg->type == ix::WebSocketMessageType::Close)
+                {
+                    TLogger() << "CLIENT: Close";
+                }
+                else if (msg->type == ix::WebSocketMessageType::Message)
+                {
+                    auto r = client.sendText("Hello, again!");
+
+                    // Block the client thread after sending a message
+                    // to make the socket buffers run full.
+                    if (r.success) msleep(1000);
+                }
+            });
+
+        server->start();
+        client.start();
+
+        // Wait for client to connect and be closed again.
+        while (!client_connected || !client_closed)
+        {
+            msleep(10);
+        }
+
+        server->stop();
+    }
+}


### PR DESCRIPTION
When sending a lot of data to a client that does not reliably drain its own socket,  it can happen that 1) the thread on the server doing the sending blocks in flushSendBuffer(). Additionally, the "receiver" thread of WebSocket::run() on the server blocks in WebSocketTransport::poll() -> sendHeartBeat() -> flushSendBuffer(). Because now WebSocket::run() is blocked, it never reads data form the client, this can result in a deadlock scenario:

    server: blocks sending to client in flushSendBuffer()
    client: also blocked while sending to server (WebSocket::run() never receives)

The clients could unblock the situation if it receives from its socket. If the client doesn't do so, this change allows the server to close the socket after a configurable timeout that is honored during flushSendBuffer(). The callback will see "Send timeout" as close reason and an abnormal close code.

---

I've ran into this a few times during development/testing and forcefully disconnecting the client after 5 seconds or so and logging the reason in the server logs is a better experience than observing a "freeze" and looking with gdb what the thread stacks look like :-)

```
Thread 8 (Thread 0x742faf7fe6c0 (LWP 44856) "zk/ws-reply-thr"):
#0  0x0000742fe771b4fd in __GI___poll (fds=fds@entry=0x742faf7f9e40, nfds=nfds@entry=2, timeout=timeout@entry=10) at ..<...>/poll.c:29
#1  0x000057f624993f88 in poll (__timeout=10, __nfds=2, __fds=0x742faf7f9e40) at <...>/poll2.h:39
#2  ix::poll (fds=fds@entry=0x742faf7f9e40, nfds=2, timeout=timeout@entry=10, event=event@entry=0x742faf7f9e38) at <...>/IXNetSystem.cpp:288
#3  0x000057f62498f3e9 in ix::Socket::poll (readyToRead=readyToRead@entry=false, timeoutMs=timeoutMs@entry=10, sockfd=81, selectInterrupt=...) at <...>/IXSocket.cpp:97
#4  0x000057f62498f5ba in ix::Socket::isReadyToWrite (this=<optimized out>, timeoutMs=timeoutMs@entry=10) at <...>/IXSocket.cpp:196
#5  0x000057f6249a090f in ix::WebSocketTransport::flushSendBuffer (this=this@entry=0x742f80000b80) at <...>/unique_ptr.h:199
#6  0x000057f6249a12b6 in ix::WebSocketTransport::sendData (this=this@entry=0x742f80000b80, type=type@entry=ix::WebSocketTransport::wsheader_type::TEXT_FRAME, message=..., compress=<optimized out>, onProgressCallback=...) at <...>/IXWebSocketTransport.cpp:938
#7  0x000057f6249a156f in ix::WebSocketTransport::sendText (this=this@entry=0x742f80000b80, message=..., onProgressCallback=...) at <...>/IXWebSocketTransport.cpp:1062
#8  0x000057f624996ddb in ix::WebSocket::sendMessage (this=0x742f80000b80, message=..., sendMessageKind=sendMessageKind@entry=ix::SendMessageKind::Text, onProgressCallback=...) at <...>/IXWebSocket.cpp:557
#9  0x000057f624996fc9 in ix::WebSocket::sendUtf8Text (this=<optimized out>, text=..., onProgressCallback=...) at <...>/IXWebSocket.cpp:511
#10 0x000057f6240e89d8 in zeek::cluster::websocket::detail::ixwebsocket::IxWebSocketClient::SendText (this=0x742f80009160, sv=...) at <...>/WebSocket-IXWebSocket.cc:47           
```

```
Thread 5 (Thread 0x742fadffb6c0 (LWP 45682) "Srv:ws:0"):
#0  0x0000742fe771b4fd in __GI___poll (fds=fds@entry=0x742fadff6900, nfds=nfds@entry=2, timeout=timeout@entry=10) at ..<...>/poll.c:29
#1  0x000057f624993f88 in poll (__timeout=10, __nfds=2, __fds=0x742faf7f9e40) at <...>/poll2.h:39
#2  ix::poll (fds=fds@entry=0x742fadff6900, nfds=2, timeout=timeout@entry=10, event=event@entry=0x742fadff68f8) at <...>/IXNetSystem.cpp:288
#3  0x000057f62498f3e9 in ix::Socket::poll (readyToRead=readyToRead@entry=false, timeoutMs=timeoutMs@entry=10, sockfd=81, selectInterrupt=...) at <...>/IXSocket.cpp:97
#4  0x000057f62498f5ba in ix::Socket::isReadyToWrite (this=<optimized out>, timeoutMs=timeoutMs@entry=10) at <...>/IXSocket.cpp:196
#5  0x000057f6249a090f in ix::WebSocketTransport::flushSendBuffer (this=this@entry=0x742f80000b80) at <...>/unique_ptr.h:199
#6  0x000057f6249a12b6 in ix::WebSocketTransport::sendData (this=this@entry=0x742f80000b80, type=type@entry=ix::WebSocketTransport::wsheader_type::PING, message=..., compress=compress@entry=false, onProgressCallback=...) at <...>/IXWebSocketTransport.cpp:938
#7  0x000057f6249a1435 in ix::WebSocketTransport::sendPing (this=this@entry=0x742f80000b80, message=...) at <...>/IXWebSocketTransport.cpp:1039
#8  0x000057f6249a1b4b in ix::WebSocketTransport::sendHeartBeat (this=this@entry=0x742f80000b80, pingMessage=<optimized out>) at <...>/IXWebSocketTransport.cpp:280
#9  0x000057f6249a2324 in ix::WebSocketTransport::poll (this=this@entry=0x742f80000b80) at <...>/IXWebSocketTransport.cpp:330
#10 0x000057f62499918c in ix::WebSocket::run (this=this@entry=0x742f80000b80) at <...>/IXWebSocket.cpp:398
```