### PR TITLE
Fix double-close of _serverFd in SocketServer teardown

### DIFF
--- a/ixwebsocket/IXSocketServer.cpp
+++ b/ixwebsocket/IXSocketServer.cpp
@@ -95,6 +95,7 @@ namespace ix
                << "at address " << _host << ":" << _port << " : " << strerror(Socket::getErrno());
 
             Socket::closeSocket(_serverFd);
+            _serverFd = -1;
             return std::make_pair(false, ss.str());
         }
 
@@ -113,6 +114,7 @@ namespace ix
                    << strerror(Socket::getErrno());
 
                 Socket::closeSocket(_serverFd);
+                _serverFd = -1;
                 return std::make_pair(false, ss.str());
             }
 
@@ -125,6 +127,7 @@ namespace ix
                    << strerror(Socket::getErrno());
 
                 Socket::closeSocket(_serverFd);
+                _serverFd = -1;
                 return std::make_pair(false, ss.str());
             }
         }
@@ -143,6 +146,7 @@ namespace ix
                    << strerror(Socket::getErrno());
 
                 Socket::closeSocket(_serverFd);
+                _serverFd = -1;
                 return std::make_pair(false, ss.str());
             }
 
@@ -155,6 +159,7 @@ namespace ix
                    << strerror(Socket::getErrno());
 
                 Socket::closeSocket(_serverFd);
+                _serverFd = -1;
                 return std::make_pair(false, ss.str());
             }
         }
@@ -169,6 +174,7 @@ namespace ix
                << "at address " << _host << ":" << _port << " : " << strerror(Socket::getErrno());
 
             Socket::closeSocket(_serverFd);
+            _serverFd = -1;
             return std::make_pair(false, ss.str());
         }
 
@@ -231,7 +237,16 @@ namespace ix
         }
 
         _conditionVariable.notify_one();
-        Socket::closeSocket(_serverFd);
+
+        // stop() runs again from ~WebSocketServer() and ~SocketServer(), so
+        // close the listening fd exactly once: a second close of the stale
+        // number would destroy whatever descriptor another thread has since
+        // opened with it.
+        if (_serverFd != -1)
+        {
+            Socket::closeSocket(_serverFd);
+            _serverFd = -1;
+        }
     }
 
     void SocketServer::setConnectionStateFactory(


### PR DESCRIPTION
Hi, I'm using IXWebSocket in https://github.com/openglad/openglad, and ran into an issue when using this in a multithreaded setting.

It seems that `SocketServer::stop()` closes `_serverFd` but never clears it, and stop() runs again from both `~WebSocketServer()` and `~SocketServer()`, so every teardown closes the same fd number two or three times. If another thread opens a descriptor between those closes, the kernel reuses the number and the stale close destroys it. I was hitting intermittent process aborts ("Unexpected error 9 on netlink descriptor", glibc's getaddrinfo netlink probe) whenever a DNS lookup in another thread raced a server teardown.

This PR sets `_serverFd` to -1 after closing it (including in error paths), like what seems to happen to `_sockfd` currently elsewhere in the code. This seems to have fixed it for me.