### PR TITLE
Fix OpenSSL cert validation when host is an IP address (#581)

### DIFF
--- a/ixwebsocket/IXSocketOpenSSL.cpp
+++ b/ixwebsocket/IXSocketOpenSSL.cpp
@@ -9,6 +9,7 @@
 
 #include "IXSocketOpenSSL.h"
 
+#include "IXNetSystem.h"
 #include "IXSocketConnect.h"
 #include "IXUniquePtr.h"
 #include <cassert>
@@ -768,7 +769,21 @@ namespace ix
             if (!_tlsOptions.disable_hostname_validation)
             {
                 X509_VERIFY_PARAM* param = SSL_get0_param(_ssl_connection);
-                X509_VERIFY_PARAM_set1_host(param, host.c_str(), host.size());
+
+                // When the host is an IP address (literal IPv4 or IPv6), it must be
+                // validated against the certificate's iPAddress SAN entries rather
+                // than the dNSName ones. X509_VERIFY_PARAM_set1_host only checks
+                // dNSName / CN, so it would always fail for IP literals.
+                struct in6_addr addr;
+                if (ix::inet_pton(AF_INET, host.c_str(), &addr) == 1 ||
+                    ix::inet_pton(AF_INET6, host.c_str(), &addr) == 1)
+                {
+                    X509_VERIFY_PARAM_set1_ip_asc(param, host.c_str());
+                }
+                else
+                {
+                    X509_VERIFY_PARAM_set1_host(param, host.c_str(), host.size());
+                }
             }
 #endif
             handshakeSuccessful = openSSLClientHandshake(host, errMsg, isCancellationRequested);


### PR DESCRIPTION
Fixes #581

## Problem

When connecting as a TLS client to a host specified as a literal IP address (e.g. `wss://127.0.0.1:44300/`) with OpenSSL as the TLS provider, x509 certificate verification always fails — even when the server certificate carries a matching `iPAddress` Subject Alternative Name.

The cause is that `SocketOpenSSL::connect` unconditionally calls `X509_VERIFY_PARAM_set1_host`, which only validates against `dNSName` / CN SAN entries. IP literals must instead be validated against `iPAddress` SAN entries.

## Fix

Detect whether `host` is an IPv4 or IPv6 literal using the existing `ix::inet_pton` helper, and in that case validate via `X509_VERIFY_PARAM_set1_ip_asc`. DNS names keep using `X509_VERIFY_PARAM_set1_host` as before.

This follows the approach suggested in the issue, made portable (avoids the Windows-only `in_addr::S_un` union member) and using the library's own `inet_pton` wrapper.

## Testing

- Builds cleanly with `-DUSE_TLS=ON -DUSE_OPEN_SSL=ON` (OpenSSL 3.6.1).
- The reporter validated the same approach against a self-signed CA with a certificate whose SAN was `DNS=localhost, IPAddress=127.0.0.1`, connecting via both `wss://127.0.0.1:44300/` and `wss://localhost:44300/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)