### PR TITLE
Avoid AI_ADDRCONFIG netlink path for DNS lookups (#560, #524)

### DIFF
--- a/ixwebsocket/IXDNSLookup.cpp
+++ b/ixwebsocket/IXDNSLookup.cpp
@@ -61,14 +61,44 @@ namespace ix
     {
         struct addrinfo hints;
         memset(&hints, 0, sizeof(hints));
-        hints.ai_flags = AI_ADDRCONFIG | AI_NUMERICSERV;
         hints.ai_family = AF_UNSPEC;
         hints.ai_socktype = SOCK_STREAM;
+        hints.ai_flags = AI_NUMERICSERV;
+
+        // When the hostname is a numeric IP literal there is no name to resolve.
+        // Setting AI_NUMERICHOST short-circuits getaddrinfo and, importantly, lets
+        // us avoid AI_ADDRCONFIG: on glibc that flag enumerates the configured
+        // interfaces through a netlink socket (__check_pf), a path that can abort
+        // the whole process inside getaddrinfo (issue #560, reproduced with
+        // "127.0.0.1") and that also fails to resolve loopback when the machine is
+        // offline (issue #524).
+        struct in6_addr dummy;
+        bool numericHost = ix::inet_pton(AF_INET, hostname.c_str(), &dummy) == 1 ||
+                           ix::inet_pton(AF_INET6, hostname.c_str(), &dummy) == 1;
+        if (numericHost)
+        {
+            hints.ai_flags |= AI_NUMERICHOST;
+        }
+        else
+        {
+            hints.ai_flags |= AI_ADDRCONFIG;
+        }
 
         std::string sport = std::to_string(port);
 
-        struct addrinfo* res;
+        struct addrinfo* res = nullptr;
         int getaddrinfo_result = getaddrinfo(hostname.c_str(), sport.c_str(), &hints, &res);
+
+        // AI_ADDRCONFIG only returns addresses for families that have a configured,
+        // non-loopback interface, so a host that resolves to loopback (e.g.
+        // "localhost") fails to resolve when there is no network. Retry once
+        // without the flag before giving up (issue #524).
+        if (getaddrinfo_result != 0 && !numericHost)
+        {
+            hints.ai_flags &= ~AI_ADDRCONFIG;
+            getaddrinfo_result = getaddrinfo(hostname.c_str(), sport.c_str(), &hints, &res);
+        }
+
         if (getaddrinfo_result)
         {
             errMsg = gai_strerror(getaddrinfo_result);


### PR DESCRIPTION
Fixes #560
Fixes #524

## Problem

`DNSLookup::getAddrInfo` always passed `AI_ADDRCONFIG` to `getaddrinfo`:

```cpp
hints.ai_flags = AI_ADDRCONFIG | AI_NUMERICSERV;
```

That flag causes two distinct failures:

- **#560 (crash):** on glibc, `AI_ADDRCONFIG` enumerates the configured interfaces through a **netlink socket** (`__check_pf`). Under heavy threaded churn that path can abort the whole process from inside `getaddrinfo` (`__netlink_assert_response` → `SIGABRT`). The reported reproducer connects to `127.0.0.1` — a numeric literal that needs no name resolution at all.
- **#524 (offline localhost):** `AI_ADDRCONFIG` only returns addresses for families with a configured **non-loopback** interface. With no network (cable unplugged / no wifi), even `localhost` fails to resolve.

## Fix

1. **Numeric IP literals** (detected with the library's `inet_pton`) now use `AI_NUMERICHOST` and **drop** `AI_ADDRCONFIG`. There's no name to resolve, so glibc skips the netlink enumeration entirely — directly avoiding the #560 abort for IP hosts, and making literal lookups faster. This covers the exact `127.0.0.1` reproducer.
2. **Real hostnames** keep `AI_ADDRCONFIG` for its intended benefit, but if the first `getaddrinfo` fails we **retry once without it**, so loopback-resolving names still work offline (#524). No new API/config knob required.

## Testing

- Builds clean (`-DUSE_TLS=ON -DUSE_OPEN_SSL=ON`, `CMAKE_CXX_STANDARD 11`).
- Smoke test via `DNSLookup::resolve`: `127.0.0.1`, `::1`, `8.8.8.8` (numeric path) and `localhost` (AI_ADDRCONFIG path) all resolve correctly.

## Notes / scope

- This is the cleanest mitigation for the #560 reproducer (numeric host → no netlink). For *non-numeric* hostnames under extreme threaded churn the glibc netlink abort is a deeper libc-level issue; if that surfaces in practice, a follow-up could drop `AI_ADDRCONFIG` more broadly, but that has IPv4/IPv6 selection trade-offs so I kept this change conservative.
- #565 (double callback on DNS fail) is a separate auto-reconnection behavior, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)