### PR TITLE
Bump version to 12.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.4.1...3.17.2)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake;${CMAKE_MODULE_PATH}")
 
-project(ixwebsocket LANGUAGES C CXX VERSION 12.0.0)
+project(ixwebsocket LANGUAGES C CXX VERSION 12.0.1)
 
 set (CMAKE_CXX_STANDARD 11)
 set (CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Prepares the 12.0.1 release. v12.0.0 shipped while CMakeLists still read 11.4.6 (fixed by #582); this sets the project version to 12.0.1 to cover the fixes merged since v12.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)