### PR TITLE
Fix TLS 1.3 reads with mbedtls, and errno signaling on Windows

### DIFF
--- a/ixwebsocket/IXNetSystem.h
+++ b/ixwebsocket/IXNetSystem.h
@@ -34,6 +34,7 @@
 #undef EINPROGRESS
 #undef EBADF
 #undef EINVAL
+#undef ECONNRESET
 
 // map to WSA error codes
 #define EWOULDBLOCK WSAEWOULDBLOCK
@@ -41,6 +42,7 @@
 #define EINPROGRESS WSAEINPROGRESS
 #define EBADF WSAEBADF
 #define EINVAL WSAEINVAL
+#define ECONNRESET WSAECONNRESET
 
 // Define our own poll on Windows, as a wrapper on top of select
 typedef unsigned long int nfds_t;

--- a/ixwebsocket/IXSocket.cpp
+++ b/ixwebsocket/IXSocket.cpp
@@ -286,6 +286,17 @@ namespace ix
         return err;
     }
 
+    void Socket::setErrno(int err)
+    {
+#ifdef _WIN32
+        // getErrno() reads WSAGetLastError() on Windows, the CRT errno is
+        // invisible to it
+        WSASetLastError(err);
+#else
+        errno = err;
+#endif
+    }
+
     bool Socket::isWaitNeeded()
     {
         int err = getErrno();

--- a/ixwebsocket/IXSocket.h
+++ b/ixwebsocket/IXSocket.h
@@ -81,6 +81,7 @@ namespace ix
                                                const CancellationRequest& isCancellationRequested);
 
         static int getErrno();
+        static void setErrno(int err);
         static bool isWaitNeeded();
         static void closeSocket(socket_t fd);
 

--- a/ixwebsocket/IXSocketAppleSSL.cpp
+++ b/ixwebsocket/IXSocketAppleSSL.cpp
@@ -267,13 +267,13 @@ namespace ix
             if (status == errSSLClosedGraceful || status == errSSLClosedNoNotify ||
                 status == errSSLClosedAbort)
             {
-                errno = ECONNRESET;
+                Socket::setErrno(ECONNRESET);
                 return -1;
             }
 
             if (status == errSSLWouldBlock)
             {
-                errno = EWOULDBLOCK;
+                Socket::setErrno(EWOULDBLOCK);
                 return -1;
             }
         }
@@ -297,13 +297,13 @@ namespace ix
             if (status == errSSLClosedGraceful || status == errSSLClosedNoNotify ||
                 status == errSSLClosedAbort)
             {
-                errno = ECONNRESET;
+                Socket::setErrno(ECONNRESET);
                 return -1;
             }
 
             if (status == errSSLWouldBlock)
             {
-                errno = EWOULDBLOCK;
+                Socket::setErrno(EWOULDBLOCK);
                 return -1;
             }
         }

--- a/ixwebsocket/IXSocketMbedTLS.cpp
+++ b/ixwebsocket/IXSocketMbedTLS.cpp
@@ -347,7 +347,7 @@ namespace ix
         }
         else if (res == MBEDTLS_ERR_SSL_WANT_READ || res == MBEDTLS_ERR_SSL_WANT_WRITE)
         {
-            errno = EWOULDBLOCK;
+            Socket::setErrno(EWOULDBLOCK);
             return -1;
         }
         else
@@ -369,14 +369,30 @@ namespace ix
                 return res;
             }
 
+            // TLS 1.3 (mbedtls 3.6+): the server can send post-handshake messages
+            // (NewSessionTicket, early data) which surface as non-fatal "read again"
+            // return codes. Retry the read instead of treating them as errors.
+#if defined(MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET)
+            if (res == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET)
+            {
+                continue;
+            }
+#endif
+#if defined(MBEDTLS_ERR_SSL_RECEIVED_EARLY_DATA)
+            if (res == MBEDTLS_ERR_SSL_RECEIVED_EARLY_DATA)
+            {
+                continue;
+            }
+#endif
+
             if (res == 0)
             {
-                errno = ECONNRESET;
+                Socket::setErrno(ECONNRESET);
             }
 
             if (res == MBEDTLS_ERR_SSL_WANT_READ || res == MBEDTLS_ERR_SSL_WANT_WRITE)
             {
-                errno = EWOULDBLOCK;
+                Socket::setErrno(EWOULDBLOCK);
             }
             return -1;
         }

--- a/ixwebsocket/IXSocketOpenSSL.cpp
+++ b/ixwebsocket/IXSocketOpenSSL.cpp
@@ -837,7 +837,7 @@ namespace ix
         }
         else if (reason == SSL_ERROR_WANT_READ || reason == SSL_ERROR_WANT_WRITE)
         {
-            errno = EWOULDBLOCK;
+            Socket::setErrno(EWOULDBLOCK);
             return -1;
         }
         else
@@ -869,7 +869,7 @@ namespace ix
 
             if (reason == SSL_ERROR_WANT_READ || reason == SSL_ERROR_WANT_WRITE)
             {
-                errno = EWOULDBLOCK;
+                Socket::setErrno(EWOULDBLOCK);
             }
             return -1;
         }


### PR DESCRIPTION
Fixes #592.

## Problem

Connecting to a TLS 1.3 wss/https server (e.g. behind Cloudflare/nginx) with the mbedtls backend (mbedtls 3.6+, TLS 1.3 on by default) fails on the first read after the handshake with `Failed reading HTTP status line`.

Two issues combine:

1. **TLS 1.3 post-handshake messages treated as fatal.** In TLS 1.3 the server sends `NewSessionTicket` after the handshake. `mbedtls_ssl_read` surfaces this as `MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET` (-0x7B00), a non-fatal "read again" code (same for `MBEDTLS_ERR_SSL_RECEIVED_EARLY_DATA`). `SocketMbedTLS::recv` treated any such code as a fatal error.
2. **Would-block signaling invisible on Windows.** On `WANT_READ`/`WANT_WRITE`, recv/send set the CRT `errno`, but `Socket::getErrno()` reads `WSAGetLastError()` on Windows, so `isWaitNeeded()` aborted legitimate would-block retries. The OpenSSL backend had the same latent bug.

## Fix

- `SocketMbedTLS::recv`: retry the read on `MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET` / `MBEDTLS_ERR_SSL_RECEIVED_EARLY_DATA` (both guarded with `#if defined(...)` so older mbedtls still compiles).
- New `Socket::setErrno()` helper mirroring `getErrno()`: `WSASetLastError()` on Windows, `errno` elsewhere. Used at all TLS backend error-signaling sites (mbedtls, OpenSSL, SecureTransport), fixing the Windows would-block bug in both the mbedtls and OpenSSL backends.
- `IXNetSystem.h`: map `ECONNRESET` → `WSAECONNRESET` alongside the existing errno mappings so it round-trips through `setErrno()`/`getErrno()`.

## Verification

Reproduced and verified on macOS against real TLS 1.3 servers (mbedtls 3.6.3):

- On mbedtls 3.6.1+ the NewSessionTicket signal is opt-in (`mbedtls_ssl_conf_tls13_enable_signal_new_session_tickets`, cf. Mbed-TLS/mbedtls#9223), so to reproduce, the signal was temporarily forced on. Instrumentation confirmed `-0x7b00` coming out of `mbedtls_ssl_read`, and an HTTPS GET to cloudflare.com failed exactly as reported (on POSIX the bug is usually masked by a stale `errno == EAGAIN` from the preceding nonblocking read, which is why it mostly bites on Windows).
- With the fix, that same worst-case configuration passes: HTTPS GET returns 200 and a `wss://echo.websocket.org` round-trip echoes correctly.
- All three TLS backends (mbedtls, OpenSSL, SecureTransport) build cleanly and pass the same end-to-end test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)