### PR TITLE
Mention CORS support in the README (cf #587)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 (note from the main developer, sadly I don't have too much time to devote to this library anymore, maybe it's time to pass the maintenance to someone else more motivated ?)
 
-IXWebSocket is a C++ library for WebSocket client and server development. It has minimal dependencies (no boost), is very simple to use and support everything you'll likely need for websocket dev (SSL, deflate compression, compiles on most platforms, etc...). HTTP client and server code is also available, but it hasn't received as much testing.
+IXWebSocket is a C++ library for WebSocket client and server development. It has minimal dependencies (no boost), is very simple to use and support everything you'll likely need for websocket dev (SSL, deflate compression, compiles on most platforms, etc...). HTTP client and server code is also available, but it hasn't received as much testing. CORS is supported: custom headers such as `Access-Control-Allow-Origin` can be set on responses through the extra headers mechanism (see [#587](https://github.com/machinezone/IXWebSocket/issues/587)).
 
 It is been used on big mobile video game titles sending and receiving tons of messages since 2017 (iOS and Android). It was tested on macOS, iOS, Linux, Android, Windows and FreeBSD. Two important design goals are simplicity and correctness.
 


### PR DESCRIPTION
As noted in #587, CORS works out of the box since custom response headers such as `Access-Control-Allow-Origin` can be set through the extra headers mechanism. This adds a one-line mention of that to the README intro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)