### PR TITLE
Replace ssize_t with std::ptrdiff_t to avoid typedef clashes on MSVC (fix #537)

### DIFF
--- a/ixwebsocket/IXHttpClient.cpp
+++ b/ixwebsocket/IXHttpClient.cpp
@@ -414,7 +414,7 @@ namespace ix
         // Parse response:
         if (headers.find("Content-Length") != headers.end())
         {
-            ssize_t contentLength = -1;
+            std::ptrdiff_t contentLength = -1;
             ss.str("");
             ss << headers["Content-Length"];
             ss >> contentLength;

--- a/ixwebsocket/IXSelectInterruptPipe.cpp
+++ b/ixwebsocket/IXSelectInterruptPipe.cpp
@@ -121,7 +121,7 @@ namespace ix
         int fd = _fildes[kPipeWriteIndex];
         if (fd == -1) return false;
 
-        ssize_t ret = -1;
+        std::ptrdiff_t ret = -1;
         do
         {
             ret = ::write(fd, &value, sizeof(value));
@@ -139,7 +139,7 @@ namespace ix
 
         uint64_t value = 0;
 
-        ssize_t readret = -1;
+        std::ptrdiff_t readret = -1;
         do
         {
             readret = ::read(fd, &value, sizeof(value));

--- a/ixwebsocket/IXSocket.cpp
+++ b/ixwebsocket/IXSocket.cpp
@@ -240,7 +240,7 @@ namespace ix
         _sockfd = -1;
     }
 
-    ssize_t Socket::send(char* buffer, size_t length)
+    std::ptrdiff_t Socket::send(char* buffer, size_t length)
     {
         int flags = 0;
 #ifdef MSG_NOSIGNAL
@@ -254,12 +254,12 @@ namespace ix
 #endif
     }
 
-    ssize_t Socket::send(const std::string& buffer)
+    std::ptrdiff_t Socket::send(const std::string& buffer)
     {
         return send((char*) &buffer[0], buffer.size());
     }
 
-    ssize_t Socket::recv(void* buffer, size_t length)
+    std::ptrdiff_t Socket::recv(void* buffer, size_t length)
     {
         int flags = 0;
 #ifdef MSG_NOSIGNAL
@@ -333,7 +333,7 @@ namespace ix
         {
             if (isCancellationRequested && isCancellationRequested()) return false;
 
-            ssize_t ret = send((char*) &str[offset], len);
+            std::ptrdiff_t ret = send((char*) &str[offset], len);
 
             // We wrote some bytes, as needed, all good.
             if (ret > 0)
@@ -368,7 +368,7 @@ namespace ix
         {
             if (isCancellationRequested && isCancellationRequested()) return false;
 
-            ssize_t ret;
+            std::ptrdiff_t ret;
             ret = recv(buffer, 1);
 
             // We read one byte, as needed, all good.
@@ -434,7 +434,7 @@ namespace ix
             }
 
             size_t size = std::min(readBuffer.size(), length - bytesRead);
-            ssize_t ret = recv((char*) &readBuffer[0], size);
+            std::ptrdiff_t ret = recv((char*) &readBuffer[0], size);
 
             if (ret > 0)
             {

--- a/ixwebsocket/IXSocket.h
+++ b/ixwebsocket/IXSocket.h
@@ -7,22 +7,12 @@
 #pragma once
 
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
-
-#ifdef __APPLE__
-#include <sys/types.h>
-#endif
-
-#ifdef _WIN32
-#include <basetsd.h>
-#ifdef _MSC_VER
-typedef SSIZE_T ssize_t;
-#endif
-#endif
 
 #include "IXCancellationRequest.h"
 #include "IXNetSystem.h"
@@ -65,9 +55,9 @@ namespace ix
                              const CancellationRequest& isCancellationRequested);
         virtual void close();
 
-        virtual ssize_t send(char* buffer, size_t length);
-        ssize_t send(const std::string& buffer);
-        virtual ssize_t recv(void* buffer, size_t length);
+        virtual std::ptrdiff_t send(char* buffer, size_t length);
+        std::ptrdiff_t send(const std::string& buffer);
+        virtual std::ptrdiff_t recv(void* buffer, size_t length);
 
         // Blocking and cancellable versions, working with socket that can be set
         // to non blocking mode. Used during HTTP upgrade.

--- a/ixwebsocket/IXSocketAppleSSL.cpp
+++ b/ixwebsocket/IXSocketAppleSSL.cpp
@@ -76,7 +76,7 @@ namespace ix
 
         size_t requested_sz = *len;
 
-        ssize_t status = read(fd, data, requested_sz);
+        std::ptrdiff_t status = read(fd, data, requested_sz);
 
         if (status > 0)
         {
@@ -123,7 +123,7 @@ namespace ix
         assert(len != nullptr);
 
         size_t to_write_sz = *len;
-        ssize_t status = write(fd, data, to_write_sz);
+        std::ptrdiff_t status = write(fd, data, to_write_sz);
 
         if (status > 0)
         {
@@ -251,7 +251,7 @@ namespace ix
         Socket::close();
     }
 
-    ssize_t SocketAppleSSL::send(char* buf, size_t nbyte)
+    std::ptrdiff_t SocketAppleSSL::send(char* buf, size_t nbyte)
     {
         OSStatus status = errSSLWouldBlock;
         while (status == errSSLWouldBlock)
@@ -260,7 +260,7 @@ namespace ix
             std::lock_guard<std::mutex> lock(_mutex);
             status = SSLWrite(_sslContext, buf, nbyte, &processed);
 
-            if (processed > 0) return (ssize_t) processed;
+            if (processed > 0) return (std::ptrdiff_t) processed;
 
             // The connection was reset, inform the caller that this
             // Socket should close
@@ -281,7 +281,7 @@ namespace ix
     }
 
     // No wait support
-    ssize_t SocketAppleSSL::recv(void* buf, size_t nbyte)
+    std::ptrdiff_t SocketAppleSSL::recv(void* buf, size_t nbyte)
     {
         OSStatus status = errSSLWouldBlock;
         while (status == errSSLWouldBlock)
@@ -290,7 +290,7 @@ namespace ix
             std::lock_guard<std::mutex> lock(_mutex);
             status = SSLRead(_sslContext, buf, nbyte, &processed);
 
-            if (processed > 0) return (ssize_t) processed;
+            if (processed > 0) return (std::ptrdiff_t) processed;
 
             // The connection was reset, inform the caller that this
             // Socket should close

--- a/ixwebsocket/IXSocketAppleSSL.h
+++ b/ixwebsocket/IXSocketAppleSSL.h
@@ -30,8 +30,8 @@ namespace ix
                              const CancellationRequest& isCancellationRequested) final;
         virtual void close() final;
 
-        virtual ssize_t send(char* buffer, size_t length) final;
-        virtual ssize_t recv(void* buffer, size_t length) final;
+        virtual std::ptrdiff_t send(char* buffer, size_t length) final;
+        virtual std::ptrdiff_t recv(void* buffer, size_t length) final;
 
     private:
         static std::string getSSLErrorDescription(OSStatus status);

--- a/ixwebsocket/IXSocketMbedTLS.cpp
+++ b/ixwebsocket/IXSocketMbedTLS.cpp
@@ -335,11 +335,11 @@ namespace ix
         Socket::close();
     }
 
-    ssize_t SocketMbedTLS::send(char* buf, size_t nbyte)
+    std::ptrdiff_t SocketMbedTLS::send(char* buf, size_t nbyte)
     {
         std::lock_guard<std::mutex> lock(_mutex);
 
-        ssize_t res = mbedtls_ssl_write(&_ssl, (unsigned char*) buf, nbyte);
+        std::ptrdiff_t res = mbedtls_ssl_write(&_ssl, (unsigned char*) buf, nbyte);
 
         if (res > 0)
         {
@@ -356,13 +356,13 @@ namespace ix
         }
     }
 
-    ssize_t SocketMbedTLS::recv(void* buf, size_t nbyte)
+    std::ptrdiff_t SocketMbedTLS::recv(void* buf, size_t nbyte)
     {
         while (true)
         {
             std::lock_guard<std::mutex> lock(_mutex);
 
-            ssize_t res = mbedtls_ssl_read(&_ssl, (unsigned char*) buf, (int) nbyte);
+            std::ptrdiff_t res = mbedtls_ssl_read(&_ssl, (unsigned char*) buf, (int) nbyte);
 
             if (res > 0)
             {

--- a/ixwebsocket/IXSocketMbedTLS.h
+++ b/ixwebsocket/IXSocketMbedTLS.h
@@ -38,8 +38,8 @@ namespace ix
                              const CancellationRequest& isCancellationRequested) final;
         virtual void close() final;
 
-        virtual ssize_t send(char* buffer, size_t length) final;
-        virtual ssize_t recv(void* buffer, size_t length) final;
+        virtual std::ptrdiff_t send(char* buffer, size_t length) final;
+        virtual std::ptrdiff_t recv(void* buffer, size_t length) final;
 
     private:
         mbedtls_ssl_context _ssl;

--- a/ixwebsocket/IXSocketOpenSSL.cpp
+++ b/ixwebsocket/IXSocketOpenSSL.cpp
@@ -818,7 +818,7 @@ namespace ix
         Socket::close();
     }
 
-    ssize_t SocketOpenSSL::send(char* buf, size_t nbyte)
+    std::ptrdiff_t SocketOpenSSL::send(char* buf, size_t nbyte)
     {
         std::lock_guard<std::mutex> lock(_mutex);
 
@@ -828,7 +828,7 @@ namespace ix
         }
 
         ERR_clear_error();
-        ssize_t write_result = SSL_write(_ssl_connection, buf, (int) nbyte);
+        std::ptrdiff_t write_result = SSL_write(_ssl_connection, buf, (int) nbyte);
         int reason = SSL_get_error(_ssl_connection, (int) write_result);
 
         if (reason == SSL_ERROR_NONE)
@@ -846,7 +846,7 @@ namespace ix
         }
     }
 
-    ssize_t SocketOpenSSL::recv(void* buf, size_t nbyte)
+    std::ptrdiff_t SocketOpenSSL::recv(void* buf, size_t nbyte)
     {
         while (true)
         {
@@ -858,7 +858,7 @@ namespace ix
             }
 
             ERR_clear_error();
-            ssize_t read_result = SSL_read(_ssl_connection, buf, (int) nbyte);
+            std::ptrdiff_t read_result = SSL_read(_ssl_connection, buf, (int) nbyte);
 
             if (read_result > 0)
             {

--- a/ixwebsocket/IXSocketOpenSSL.h
+++ b/ixwebsocket/IXSocketOpenSSL.h
@@ -33,8 +33,8 @@ namespace ix
                              const CancellationRequest& isCancellationRequested) final;
         virtual void close() final;
 
-        virtual ssize_t send(char* buffer, size_t length) final;
-        virtual ssize_t recv(void* buffer, size_t length) final;
+        virtual std::ptrdiff_t send(char* buffer, size_t length) final;
+        virtual std::ptrdiff_t recv(void* buffer, size_t length) final;
 
     private:
         void openSSLInitialize();

--- a/ixwebsocket/IXUdpSocket.cpp
+++ b/ixwebsocket/IXUdpSocket.cpp
@@ -107,20 +107,20 @@ namespace ix
         return true;
     }
 
-    ssize_t UdpSocket::sendto(const std::string& buffer)
+    std::ptrdiff_t UdpSocket::sendto(const std::string& buffer)
     {
-        return (ssize_t)::sendto(
+        return (std::ptrdiff_t)::sendto(
             _sockfd, buffer.data(), static_cast<int>(buffer.size()), 0, (struct sockaddr*) &_server, sizeof(_server));
     }
 
-    ssize_t UdpSocket::recvfrom(char* buffer, size_t length)
+    std::ptrdiff_t UdpSocket::recvfrom(char* buffer, size_t length)
     {
 #ifdef _WIN32
         int addressLen = (int) sizeof(_server);
 #else
         socklen_t addressLen = (socklen_t) sizeof(_server);
 #endif
-        return (ssize_t)::recvfrom(
+        return (std::ptrdiff_t)::recvfrom(
             _sockfd, buffer, static_cast<int>(length), 0, (struct sockaddr*) &_server, &addressLen);
     }
 } // namespace ix

--- a/ixwebsocket/IXUdpSocket.h
+++ b/ixwebsocket/IXUdpSocket.h
@@ -7,15 +7,9 @@
 #pragma once
 
 #include <atomic>
+#include <cstddef>
 #include <memory>
 #include <string>
-
-#ifdef _WIN32
-#include <basetsd.h>
-#ifdef _MSC_VER
-typedef SSIZE_T ssize_t;
-#endif
-#endif
 
 #include "IXNetSystem.h"
 
@@ -29,8 +23,8 @@ namespace ix
 
         // Virtual methods
         bool init(const std::string& host, int port, std::string& errMsg);
-        ssize_t sendto(const std::string& buffer);
-        ssize_t recvfrom(char* buffer, size_t length);
+        std::ptrdiff_t sendto(const std::string& buffer);
+        std::ptrdiff_t recvfrom(char* buffer, size_t length);
 
         void close();
 

--- a/ixwebsocket/IXWebSocketTransport.cpp
+++ b/ixwebsocket/IXWebSocketTransport.cpp
@@ -1072,7 +1072,7 @@ namespace ix
 
         while (_txbuf.size())
         {
-            ssize_t ret = 0;
+            std::ptrdiff_t ret = 0;
             {
                 std::lock_guard<std::mutex> lock(_socketMutex);
                 ret = _socket->send((char*) &_txbuf[0], _txbuf.size());
@@ -1116,7 +1116,7 @@ namespace ix
             // There's also no point in reading more bytes than needed.
             if (_rxbufWanted > 0 && _rxbuf.size() >= _rxbufWanted) break;
 
-            ssize_t ret = _socket->recv((char*) &_readbuf[0], _readbuf.size());
+            std::ptrdiff_t ret = _socket->recv((char*) &_readbuf[0], _readbuf.size());
 
             if (ret < 0 && Socket::isWaitNeeded())
             {


### PR DESCRIPTION
Fixes #537.

MSVC does not provide `ssize_t`, so `IXSocket.h` and `IXUdpSocket.h` injected a global-namespace `typedef SSIZE_T ssize_t;`. That collides (C2371) with other Windows libraries that define their own `ssize_t` shim with a different underlying type, as reported in #537.

This replaces every `ssize_t` in the library with `std::ptrdiff_t` and removes both typedefs along with the now-unneeded `<basetsd.h>`/`<sys/types.h>` shim includes, so IXWebSocket no longer defines anything in the global namespace.

`std::ptrdiff_t` is the same underlying type as `ssize_t`/`SSIZE_T` on all supported 64-bit platforms (and 32-bit Linux/macOS), so this is not an ABI break there. The one caveat is 32-bit MSVC, where `LONG_PTR` is `long` but `ptrdiff_t` is `int` — same size, different mangling — so external code subclassing `ix::Socket` and overriding `send`/`recv` would need a one-line signature update on that platform.

Verified locally on macOS (SecureTransport backend, Debug, `USE_WS=1 USE_TEST=1`): full build passes and the test suite gives the same results as unmodified master (16/18 pass; `IXSocketConnectTest` and `IXDNSLookupTest` fail identically on master in my environment — they depend on live network/DNS). OpenSSL, mbedTLS, and Windows paths are exercised by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)