### PR TITLE
permessage-deflate: make client/server_max_window_bits optional in the offer

### DIFF
--- a/ixwebsocket/IXWebSocketPerMessageDeflateOptions.cpp
+++ b/ixwebsocket/IXWebSocketPerMessageDeflateOptions.cpp
@@ -27,13 +27,15 @@ namespace ix
         bool clientNoContextTakeover,
         bool serverNoContextTakeover,
         uint8_t clientMaxWindowBits,
-        uint8_t serverMaxWindowBits)
+        uint8_t serverMaxWindowBits,
+        bool sendClientServerMaxWindowBits)
     {
         _enabled = enabled;
         _clientNoContextTakeover = clientNoContextTakeover;
         _serverNoContextTakeover = serverNoContextTakeover;
         _clientMaxWindowBits = clientMaxWindowBits;
         _serverMaxWindowBits = serverMaxWindowBits;
+        _sendClientServerMaxWindowBits = sendClientServerMaxWindowBits;
 
         sanitizeClientMaxWindowBits();
     }
@@ -59,6 +61,7 @@ namespace ix
         _enabled = false;
         _clientNoContextTakeover = false;
         _serverNoContextTakeover = false;
+        _sendClientServerMaxWindowBits = true;
         _clientMaxWindowBits = kDefaultClientMaxWindowBits;
         _serverMaxWindowBits = kDefaultServerMaxWindowBits;
 
@@ -128,8 +131,11 @@ namespace ix
         if (_clientNoContextTakeover) ss << "; client_no_context_takeover";
         if (_serverNoContextTakeover) ss << "; server_no_context_takeover";
 
-        ss << "; server_max_window_bits=" << static_cast<int>(_serverMaxWindowBits);
-        ss << "; client_max_window_bits=" << static_cast<int>(_clientMaxWindowBits);
+        if (_sendClientServerMaxWindowBits)
+        {
+            ss << "; server_max_window_bits=" << static_cast<int>(_serverMaxWindowBits);
+            ss << "; client_max_window_bits=" << static_cast<int>(_clientMaxWindowBits);
+        }
 
         ss << "\r\n";
 
@@ -166,6 +172,11 @@ namespace ix
     uint8_t WebSocketPerMessageDeflateOptions::getServerMaxWindowBits() const
     {
         return _serverMaxWindowBits;
+    }
+
+    bool WebSocketPerMessageDeflateOptions::getSendClientServerMaxWindowBits() const
+    {
+        return _sendClientServerMaxWindowBits;
     }
 
     bool WebSocketPerMessageDeflateOptions::startsWith(const std::string& str,

--- a/ixwebsocket/IXWebSocketPerMessageDeflateOptions.h
+++ b/ixwebsocket/IXWebSocketPerMessageDeflateOptions.h
@@ -19,7 +19,8 @@ namespace ix
             bool clientNoContextTakeover = false,
             bool serverNoContextTakeover = false,
             uint8_t clientMaxWindowBits = kDefaultClientMaxWindowBits,
-            uint8_t serverMaxWindowBits = kDefaultServerMaxWindowBits);
+            uint8_t serverMaxWindowBits = kDefaultServerMaxWindowBits,
+            bool sendClientServerMaxWindowBits = true);
 
         WebSocketPerMessageDeflateOptions(std::string extension);
 
@@ -29,6 +30,7 @@ namespace ix
         bool getServerNoContextTakeover() const;
         uint8_t getServerMaxWindowBits() const;
         uint8_t getClientMaxWindowBits() const;
+        bool getSendClientServerMaxWindowBits() const;
 
         static bool startsWith(const std::string& str, const std::string& start);
         static std::string removeSpaces(const std::string& str);
@@ -40,6 +42,7 @@ namespace ix
         bool _enabled;
         bool _clientNoContextTakeover;
         bool _serverNoContextTakeover;
+        bool _sendClientServerMaxWindowBits;
         uint8_t _clientMaxWindowBits;
         uint8_t _serverMaxWindowBits;
 


### PR DESCRIPTION
## Problem

Connecting as a client to a server that rejects a `permessage-deflate` offer carrying `client_max_window_bits`/`server_max_window_bits` fails, and there is no way to leave those parameters out.

`generateHeader()` unconditionally appends `; server_max_window_bits=15; client_max_window_bits=15`. 15 is the default window size in [RFC 7692 (section 7.1.2)](https://datatracker.ietf.org/doc/html/rfc7692#section-7.1.2), so advertising `=15` conveys nothing the peer would not already assume — the parameters only carry meaning when you want a window *smaller* than 15 to save memory. Some servers and gateways are strict about the extension parameters they accept and reject an offer that includes them, and the library gives no way to suppress them.

## Fix

Add a `sendClientServerMaxWindowBits` flag on `WebSocketPerMessageDeflateOptions` that gates emitting the two parameters.

- Defaults to `true`, so the generated header is identical for anyone who does not set it.
- Set it to `false` to send a bare `permessage-deflate` offer:

  ```cpp
  ix::WebSocketPerMessageDeflateOptions opts(true, false, false, 15, 15, false);
  webSocket.setPerMessageDeflateOptions(opts);
  ```

- The new parameter is appended at the end of the constructor, so existing positional calls are unaffected.
- The header-parsing constructor now initializes the flag as well; it was left unset before.

## Verification

Built the library (zlib backend) and exercised `generateHeader()` both ways:

```
default: Sec-WebSocket-Extensions: permessage-deflate; server_max_window_bits=15; client_max_window_bits=15
off:     Sec-WebSocket-Extensions: permessage-deflate
```

The default output matches the current header exactly; with the flag off the two parameters are gone. The existing `per-message-deflate-codec` test still passes.