### PR TITLE
Allow setting additional openssl CTX options from client applications (#600)

### DIFF
--- a/ixwebsocket/IXSocketOpenSSL.cpp
+++ b/ixwebsocket/IXSocketOpenSSL.cpp
@@ -561,6 +561,11 @@ namespace ix
             return false;
         }
 
+        if (_tlsOptions.hasAdditionalOptions())
+        {
+            SSL_CTX_set_options(_ssl_context, _tlsOptions.additional_openssl_ctx_options);
+        }
+
         return true;
     }
 
@@ -598,7 +603,7 @@ namespace ix
                         SSL_CTX_set_mode(_ssl_context, SSL_MODE_ENABLE_PARTIAL_WRITE);
                         SSL_CTX_set_mode(_ssl_context, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
                         SSL_CTX_set_options(_ssl_context,
-                                            SSL_OP_ALL | SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
+                                            SSL_OP_ALL | SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | _tlsOptions.additional_openssl_ctx_options);
                     }
                 }
             }

--- a/ixwebsocket/IXSocketTLSOptions.cpp
+++ b/ixwebsocket/IXSocketTLSOptions.cpp
@@ -49,6 +49,11 @@ namespace ix
         return true;
     }
 
+    bool SocketTLSOptions::hasAdditionalOptions() const
+    {
+        return additional_openssl_ctx_options != 0;
+    }
+
     bool SocketTLSOptions::hasCertAndKey() const
     {
         return !certFile.empty() && !keyFile.empty();

--- a/ixwebsocket/IXSocketTLSOptions.h
+++ b/ixwebsocket/IXSocketTLSOptions.h
@@ -36,6 +36,11 @@ namespace ix
         // whether to skip validating the peer's hostname against the certificate presented
         bool disable_hostname_validation = false;
 
+        // additional OpenSSL CTX options to set when calling SSL_CTX_set_options during the handshake
+        uint64_t additional_openssl_ctx_options = 0;
+
+        bool hasAdditionalOptions() const;
+
         bool hasCertAndKey() const;
 
         bool isUsingSystemDefaults() const;


### PR DESCRIPTION
## Problem

OpenSSL 3.x behavior with respect to abruptly closed sockets when connecting to the WebSocket server results in spurious error messages.  The workaround as described in https://github.com/openssl/openssl/discussions/22690 is to call `SSL_set_options` (or `SSL_CTX_set_options` with option `SSL_OP_IGNORE_UNEXPECTED_EOF`.  However, IXWebSockets does not expose the ability to do so from client applications.  (fixes #600)

## Fix

Add `int additional_openssl_ctx_options` to `ix::SocketTLSOptions`

- Defaults to `0`, so the behavior is unchanged for existing applications.
- clients can set it to a desired value to include the options in the `SSL_CTX_set_options` calls during client and server socket handshakes
- adds a call to `SSL_CTX_set_options` during `SocketOpenSSL::handleTLSOptions` to handle the client handshake
- appends the options to the existing `SSL_CTX_set_options` call in `SocketOpenSSL::accept` to handle the server handshake

## Verification

Built the library on Linux RH8 and tested our application with and without setting `SocketTLSOptions::additional_openssl_ctx_options` to `SSL_OP_IGNORE_UNEXPECTED_EOF` and confirmed that the application functions in both modes, but with the additional option the spurious error messages are squelched.
