### PR TITLE
Support FD_CLOEXEC for server and client sockets created by SocketServer

### DIFF
--- a/ixwebsocket/IXSocket.cpp
+++ b/ixwebsocket/IXSocket.cpp
@@ -318,6 +318,16 @@ namespace ix
 #endif
     }
 
+    bool Socket::setCloseOnExec(socket_t fd)
+    {
+#ifdef _WIN32
+        // Not implemented on Windows.
+        return false;
+#else
+        return ::fcntl(fd, F_SETFD, FD_CLOEXEC) == 0;
+#endif
+    }
+
     bool Socket::init(std::string& errorMsg)
     {
         return _selectInterrupt->init(errorMsg);

--- a/ixwebsocket/IXSocket.h
+++ b/ixwebsocket/IXSocket.h
@@ -74,6 +74,7 @@ namespace ix
         static void setErrno(int err);
         static bool isWaitNeeded();
         static void closeSocket(socket_t fd);
+        static bool setCloseOnExec(socket_t fd);
 
         static PollResultType poll(bool readyToRead,
                                    int timeoutMs,

--- a/ixwebsocket/IXSocketServer.cpp
+++ b/ixwebsocket/IXSocketServer.cpp
@@ -102,6 +102,20 @@ namespace ix
             return std::make_pair(false, ss.str());
         }
 
+        if (_closeOnExec)
+        {
+            if (!Socket::setCloseOnExec(_serverFd))
+            {
+                std::stringstream ss;
+                ss << "SocketServer::listen() error setting close on exec: "
+                   << strerror(Socket::getErrno());
+
+                Socket::closeSocket(_serverFd);
+                _serverFd = -1;
+                return std::make_pair(false, ss.str());
+            }
+        }
+
         // Make that socket reusable. (allow restarting this server at will)
         int enable = 1;
         if (setsockopt(_serverFd, SOL_SOCKET, SO_REUSEADDR, (char*) &enable, sizeof(enable)) < 0)
@@ -371,6 +385,22 @@ namespace ix
                 Socket::closeSocket(clientFd);
 
                 continue;
+            }
+
+            if (_closeOnExec)
+            {
+                if (!Socket::setCloseOnExec(clientFd))
+                {
+                    int err = Socket::getErrno();
+                    std::stringstream ss;
+                    ss << "SocketServer::run() error setting close on exec: " << err << ", "
+                       << strerror(err);
+                    logError(ss.str());
+
+                    Socket::closeSocket(clientFd);
+
+                    continue;
+                }
             }
 
             // Retrieve connection info, the ip address of the remote peer/client)

--- a/ixwebsocket/IXSocketServer.h
+++ b/ixwebsocket/IXSocketServer.h
@@ -74,7 +74,13 @@ namespace ix
 
         void setTLSOptions(const SocketTLSOptions& socketTLSOptions);
 
-        int  getPort();
+        // Set FD_CLOEXEC on server and client file descriptors.
+        void setCloseOnExec()
+        {
+            _closeOnExec = true;
+        }
+
+        int getPort();
         std::string getHost();
         int getBacklog();
         std::size_t getMaxConnections();
@@ -93,6 +99,7 @@ namespace ix
         int _backlog;
         size_t _maxConnections;
         int _addressFamily;
+        bool _closeOnExec = false;
 
         // socket for accepting connections
         socket_t _serverFd;


### PR DESCRIPTION
This adds a method setCloseOnExec() to enable setting FD_CLOEXEC on the server and client file descriptors before starting to listen or initiating the WebSocket handshake. This is useful if a process spawns child processes via system() or otherwise, but does not want have WebSocket specific sockets to be inherited to child processes.