### PR TITLE
CI: use the preinstalled mingw-w64 and ninja on windows-latest

### DIFF
--- a/.github/workflows/unittest_windows_gcc.yml
+++ b/.github/workflows/unittest_windows_gcc.yml
@@ -11,20 +11,16 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: seanmiddleditch/gha-setup-ninja@master
-    - uses: bsergean/setup-mingw@d79ce405bac9edef3a1726ef00554a56f0bafe66
+    - uses: actions/checkout@v4
+    # No toolchain setup step: windows-latest ships mingw-w64 (gcc, ucrt, posix
+    # threads) at C:\mingw64\bin and ninja, both already on PATH.
     - run: |
         mkdir build
         cd build
-        cmake -GNinja -DCMAKE_CXX_COMPILER=c++ -DCMAKE_C_COMPILER=cc -DUSE_WS=1 -DUSE_TEST=1 -DUSE_ZLIB=0 -DCMAKE_UNITY_BUILD=ON ..
+        cmake -GNinja -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DUSE_WS=1 -DUSE_TEST=1 -DUSE_ZLIB=0 -DCMAKE_UNITY_BUILD=ON ..
     - run: |
         cd build
         ninja
     - run: |
         cd build
         ctest -V
-        # ninja test
-
-#- run: ../build/test/ixwebsocket_unittest.exe
-# working-directory: test


### PR DESCRIPTION
The `setup-mingw` step in the `windows_gcc` job takes **61 seconds** to run `choco upgrade mingw`, downloading and extracting a 102 MB 7z — and the toolchain it installs is **never used**.

The chocolatey package relocates itself to `C:\ProgramData\mingw64\mingw64\bin`, while the action appends `C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin` to `GITHUB_PATH` — a path that doesn't exist. So the compiler lookup falls through to the mingw-w64 that `windows-latest` already ships at `C:\mingw64\bin` (gcc 15.2.0, ucrt runtime, posix threads). The logs of [a recent run](https://github.com/machinezone/IXWebSocket/actions/runs/32086705622/job/95560640105) confirm it:

```
Creating link C:\mingw64\bin\cc.exe -> C:\mingw64\bin\x86_64-w64-mingw32-gcc.exe
-- The C compiler identification is GNU 15.2.0
-- Check for working C compiler: C:/mingw64/bin/cc.exe - skipped
```

The action's only real contribution was hardlinking `cc.exe`/`c++.exe` next to the mingw binaries — naming `gcc`/`g++` in the cmake invocation makes that unnecessary.

`gha-setup-ninja` goes for the same reason: it downloaded ninja 1.12.1 while the image already has 1.13.2 on PATH. Dropping it also clears the "Node.js 20 is deprecated" warning on the job.

Also bumps `actions/checkout` v1 → v4.

### Expected impact

| Step | Before | After |
|---|---|---|
| setup-ninja | 4s | — |
| setup-mingw | **63s** | — |
| cmake configure | 8s | ~8s |
| ninja build | 35s | ~35s |
| ctest | 43s | ~43s |
| **Total job** | **2m46s** | **~1m40s** |

### Note

The old action deleted `libpthread.dll.a`/`libwinpthread.dll.a` to force static winpthread linking. Without it the test binaries link `libwinpthread-1.dll` dynamically, which is fine in CI since `C:\mingw64\bin` is on the machine PATH. If `ctest` ever hits a missing-DLL error, the fix is `-DCMAKE_EXE_LINKER_FLAGS="-static"`, not restoring the action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)