### PR TITLE
Fix: Set soversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,8 +167,11 @@ if(BUILD_SHARED_LIBS)
         ${IXWEBSOCKET_HEADERS}
     )
 
-    # Set library version
-    set_target_properties(ixwebsocket PROPERTIES VERSION ${PROJECT_VERSION})
+    # Set library version and soversion
+    set_target_properties(ixwebsocket PROPERTIES
+        VERSION ${PROJECT_VERSION}
+        SOVERSION ${PROJECT_VERSION_MAJOR}
+    )
 else()
     # Static library
     add_library( ixwebsocket


### PR DESCRIPTION
Greetings!

Currently, soversion is unset, and thus resulting library defaults to full version with patch as it's soname.
This PR adds soversion definition to `CMakeLists.txt`, equal to major version.